### PR TITLE
Add current user to nix trusted-users for PRIVATE and WORK

### DIFF
--- a/hosts/private/default.nix
+++ b/hosts/private/default.nix
@@ -58,6 +58,11 @@
     };
   };
 
+  nix.settings.trusted-users = [
+    "root"
+    userName
+  ];
+
   programs.zsh.enable = true;
   security.pam.services.sudo_local.touchIdAuth = true;
   time.timeZone = "Asia/Tokyo";

--- a/hosts/work/default.nix
+++ b/hosts/work/default.nix
@@ -57,6 +57,11 @@
     };
   };
 
+  nix.settings.trusted-users = [
+    "root"
+    userName
+  ];
+
   programs.zsh.enable = true;
   security.pam.services.sudo_local.touchIdAuth = true;
   time.timeZone = "Asia/Tokyo";


### PR DESCRIPTION
## Why

Without trusted-users configuration, privileged Nix operations such as adding extra binary caches were not available for the current user.

## What

- Add nix.settings.trusted-users to both hosts/private/default.nix and hosts/work/default.nix
- Include root and userName (current user) as trusted users

## References

- https://nix.dev/manual/nix/latest/command-ref/conf-file#conf-trusted-users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * System Nix package manager trusted user settings have been updated across multiple host environments. Root and standard user accounts now have expanded trusted access permissions, enabling broader operational capabilities for package management and system administration functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->