### PR TITLE
Add Serena MCP server config for Codex

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -29,6 +29,21 @@ args = []
 startup_timeout_sec = 20
 tool_timeout_sec = 120
 
+[mcp_servers.serena]
+type = "stdio"
+command = "nix"
+args = [
+    "run",
+    "github:oraios/serena",
+    "--",
+    "start-mcp-server",
+    "--context",
+    "codex",
+    "--project-from-cwd",
+    "--open-web-dashboard",
+    "False",
+]
+
 # Model migration notice mapping
 [notice.model_migrations]
 "gpt-5.3" = "gpt-5.3-codex"


### PR DESCRIPTION
## Why

To enable stable codebase investigation from Codex via Serena MCP.

## What

Added mcp_servers.serena to config.toml.

- Uses nix run github:oraios/serena -- start-mcp-server
- Sets --context codex and --project-from-cwd
- Enables Serena MCP during Codex sessions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration for a new Serena MCP server integration with initialization parameters and dashboard access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->