### PR TITLE
Add CodeRabbit configuration for Nix-focused PR reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -22,7 +22,6 @@ reviews:
 
   path_filters:
     - "**/*.nix"
-    - "**/*.rs"
     - "**/*.yaml"
     - "**/*.yml"
     - "**/*.toml"


### PR DESCRIPTION
## Why

Automate PR review with CodeRabbit to catch Nix-specific issues
(module composition errors, infinite recursion, improper `with` scoping)
before manual review. Directory-specific instructions give the reviewer
context about each part of the flake structure.

## What

- Add `.coderabbit.yaml` with chill profile and Nix-focused tone instructions
- Configure path filters for `.nix`, `.rs`, `.yaml`, `.yml`, `.toml`, `.json`, `.sh` (excluding `flake.lock` and `result/`)
- Add per-directory review instructions for `flake.nix`, `lib/`, `modules/`, `packages/`, `hosts/`, `home/`
- Enable yamllint, gitleaks, actionlint, shellcheck, clippy; disable irrelevant linters
- Reference `CLAUDE.md` as knowledge base for review context
