### PR TITLE
Rename MYNIX_REPO_PATH to REPOSITORY_PATH and fix repository references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Validate Nix flake syntax
       run: |
         export CURRENT_USER=$(whoami)
-        export MYNIX_REPO_PATH=$(pwd)
+        export REPOSITORY_PATH=$(pwd)
         nix flake show --impure
         nix flake check --no-build --impure
 
@@ -57,5 +57,5 @@ jobs:
     - name: Dry-run build
       run: |
         export CURRENT_USER=$(whoami)
-        export MYNIX_REPO_PATH=$(pwd)
+        export REPOSITORY_PATH=$(pwd)
         nix build .#darwinConfigurations.${{ matrix.config_name }}.system --dry-run --impure

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,5 +1,5 @@
 # the name by which the project can be referenced within Serena
-project_name: "mynix"
+project_name: "nix-config"
 
 
 # list of languages for which language servers are started; choose from:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ packages/              Custom package definitions
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `CURRENT_USER` | Auto | Via `whoami` |
-| `MYNIX_REPO_PATH` | Auto | Via `pwd` |
+| `REPOSITORY_PATH` | Auto | Via `pwd` |
 
 ## Formatting
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Define your entire development and daily-use software stack as code.
 curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
 
 # Clone and apply
-git clone https://github.com/usabarashi/mynix.git
-cd mynix
+git clone https://github.com/usabarashi/nix-config.git
+cd nix-config
 nix run .#private  # or: nix run .#work
 ```
 
@@ -53,7 +53,7 @@ nix-collect-garbage -d && nix-store --gc
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `CURRENT_USER` | Auto | Detected via `whoami` |
-| `MYNIX_REPO_PATH` | Auto | Detected via `pwd` |
+| `REPOSITORY_PATH` | Auto | Detected via `pwd` |
 
 ## Build Requirements
 

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
               echo "Applying '${name}' configuration... (sudo password may be required)"
               sudo env \
                 CURRENT_USER="''${CURRENT_USER:-$(whoami)}" \
-                MYNIX_REPO_PATH="''${MYNIX_REPO_PATH:-$(pwd)}" \
+                REPOSITORY_PATH="''${REPOSITORY_PATH:-$(pwd)}" \
                 ${darwinRebuild} switch --flake ".#${name}" --impure "$@"
             ''
           );

--- a/lib/env.nix
+++ b/lib/env.nix
@@ -9,7 +9,7 @@ let
     if value != "" then value else builtins.throw fallbackMsg;
 in
 {
-  repoPath = getEnvOrThrow "MYNIX_REPO_PATH" "MYNIX_REPO_PATH environment variable must be set for multi-user sharing. Please set it to your repository path.";
+  repoPath = getEnvOrThrow "REPOSITORY_PATH" "REPOSITORY_PATH environment variable must be set for multi-user sharing. Please set it to your repository path.";
 
   currentUser = getEnvOrThrow "CURRENT_USER" "CURRENT_USER environment variable must be set. Please ensure whoami is available.";
 }


### PR DESCRIPTION
## Why

The repository was renamed from `mynix` to `nix-config`, but documentation and code still referenced the old name. The environment variable `MYNIX_REPO_PATH` also used an abbreviated, project-specific prefix inconsistent with the `CURRENT_USER` naming convention.

## What

- Fix clone URL and directory name in README from `mynix` to `nix-config`
- Rename environment variable `MYNIX_REPO_PATH` to `REPOSITORY_PATH` for naming consistency with `CURRENT_USER`
- Update all references in flake.nix, lib/env.nix, CI workflow, AGENTS.md, and README
- Update Serena project name from `mynix` to `nix-config`
