### PR TITLE
Remove Claude Code Usage Monitor from VS Code extensions

### DIFF
--- a/modules/shared/vscode-extensions.nix
+++ b/modules/shared/vscode-extensions.nix
@@ -107,17 +107,10 @@ let
     ++ (if marketplace != [ ] then extensionsFromVscodeMarketplace marketplace else [ ])
     ++ custom;
 
-  collectNestedExtensions =
-    groups:
-    builtins.concatLists (builtins.map (group: collectExtensions group) (builtins.attrValues groups));
-
 in
 {
   inherit
     programmingLanguages
     collectExtensions
-    collectNestedExtensions
     ;
-
-  extensions = collectNestedExtensions programmingLanguages;
 }

--- a/modules/shared/vscode.nix
+++ b/modules/shared/vscode.nix
@@ -9,13 +9,8 @@
 
 let
   extensionsConfig = import ./vscode-extensions.nix { inherit pkgs; };
-  inherit (extensionsConfig) collectExtensions collectNestedExtensions;
+  inherit (extensionsConfig) collectExtensions;
   inherit (extensionsConfig) programmingLanguages;
-
-  programmingLanguageExtensions = collectNestedExtensions programmingLanguages;
-  aiAssistantExtensions = collectNestedExtensions;
-
-  allExtensions = programmingLanguageExtensions ++ aiAssistantExtensions;
 in
 {
   home.packages = with pkgs; [


### PR DESCRIPTION
## Why

The Claude Code Usage Monitor VS Code extension is no longer needed and should be removed from the managed extensions configuration.

## What

- Remove the `aiAssistants` extension group and its `claude-code-usage-monitor` custom extension definition from `vscode-extensions.nix`
- Remove the `aiAssistants` export and simplify `extensions` to only aggregate `programmingLanguages`
- Update `vscode.nix` to stop importing the removed `aiAssistants` group
