### PR TITLE
Add project_doc_fallback_filenames to Codex config

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -11,6 +11,7 @@ sandbox_mode = "workspace-write"
 web_search = "live"
 notify = ["bash", "-lc", "afplay /System/Library/Sounds/Ping.aiff"]
 personality = "pragmatic"
+project_doc_fallback_filenames = ["CLAUDE.md"]
 
 # Session history
 [history]


### PR DESCRIPTION
## Why

Codex needs to discover project-level instructions when no Codex-specific doc file exists. Adding `CLAUDE.md` as a fallback filename lets Codex read the same project instructions that Claude Code already uses.

## What

- Add `project_doc_fallback_filenames = ["CLAUDE.md"]` to `config/codex/config.toml`

