### PR TITLE
Update Codex model from gpt-5.3-codex to gpt-5.4

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -1,7 +1,7 @@
 # See: https://developers.openai.com/codex/config-reference
 
 # Model
-model = "gpt-5.3-codex"
+model = "gpt-5.4"
 model_reasoning_effort = "medium"
 model_reasoning_summary = "auto"
 


### PR DESCRIPTION
## Why

OpenAI officially released GPT-5.4 as the latest model for Codex CLI. This update migrates the local Codex configuration to use the new model, aligning with the official recommendation.

## What

- Update `model` in `config/codex/config.toml` from `gpt-5.3-codex` to `gpt-5.4`

## References

- https://openai.com/index/introducing-gpt-5-4/