### PR TITLE
Add 1Password CLI to work home packages

### DIFF
--- a/home/work/default.nix
+++ b/home/work/default.nix
@@ -19,6 +19,7 @@
   };
 
   home.packages = with pkgs; [
+    _1password-cli
     gmailctl
   ];
 


### PR DESCRIPTION
## Why

Enable `op` command usage in the work environment for secure secret retrieval (e.g. via direnv or manual `op read` calls) instead of storing credentials in plaintext.

## What

- Add `_1password-cli` package to work home-manager configuration
