### PR TITLE
Enable Codex plugin under claude-code sandbox

### DIFF
--- a/config/agents/permissive-open.sb
+++ b/config/agents/permissive-open.sb
@@ -14,6 +14,7 @@
   (subpath (string-append (param "HOME_DIR") "/.cargo/registry"))
   (subpath (string-append (param "HOME_DIR") "/.cargo/git"))
   (subpath (string-append (param "HOME_DIR") "/.cargo/.global-cache"))
+  (subpath (string-append (param "HOME_DIR") "/.codex"))
   (subpath (string-append (param "HOME_DIR") "/.terraform.d/plugin-cache"))
   (subpath (string-append (param "HOME_DIR") "/Library/Keychains"))
 
@@ -26,7 +27,7 @@
   (subpath (string-append (param "HOME_DIR") "/Library/Caches"))
   (subpath "/private/tmp")
   (subpath "/private/var/tmp")
-  (regex #"^/private/var/folders/[^/]+/[^/]+/[C,T]")
+  (regex #"^/private/var/folders/[^/]+/[^/]+/[CT]")
 
   ;; Other tool-related. Please adjust according to the tool you are using
   (subpath (string-append (param "HOME_DIR") "/.npm"))

--- a/packages/claude-code-sandboxed/default.nix
+++ b/packages/claude-code-sandboxed/default.nix
@@ -2,10 +2,21 @@
   lib,
   stdenv,
   claude-code,
+  nodejs,
+  runCommand,
   writeShellScriptBin,
 }:
 
 let
+  # Expose only the `node` binary (no npm/npx/corepack) to the claude-code
+  # process tree. Required by the openai-codex plugin's companion scripts,
+  # which are executed via `node ${CLAUDE_PLUGIN_ROOT}/scripts/*.mjs`.
+  # Omitting npm prevents any `npm install` side effects from the sandbox.
+  nodeOnly = runCommand "node-only" { } ''
+    mkdir -p $out/bin
+    ln -s ${nodejs}/bin/node $out/bin/node
+  '';
+
   sandboxProfilePath = "\${HOME}/.claude/permissive-open.sb";
   errorMessages = {
     profileNotFound = "Error: Sandbox policy not found at ${sandboxProfilePath}";
@@ -16,6 +27,10 @@ let
   claudeWrapper = writeShellScriptBin "claude" ''
     # Direct path to claude-code binary
     CLAUDE_BIN="${claude-code}/bin/claude"
+
+    # Expose only `node` to the claude-code process tree (scoped, not a user
+    # install). Required by the openai-codex plugin's companion scripts.
+    export PATH="${nodeOnly}/bin:$PATH"
 
     # --no-sandbox: bypass sandbox and execute the binary directly.
     # Useful when invoked from an already-sandboxed context (e.g., Gemini CLI).

--- a/packages/claude-code-sandboxed/default.nix
+++ b/packages/claude-code-sandboxed/default.nix
@@ -4,17 +4,33 @@
   claude-code,
   nodejs,
   runCommand,
+  writeShellScript,
   writeShellScriptBin,
 }:
 
 let
+  # Stub invoked when a package manager command is resolved via the
+  # claude-code-sandboxed PATH. Ensures the "node-only" intent holds even
+  # if another node installation (e.g. Homebrew) exists in the inherited
+  # PATH, because the stub at ${nodeOnly}/bin/{npm,npx,corepack} takes
+  # precedence over any later entry.
+  unavailableStub = writeShellScript "claude-sandbox-unavailable" ''
+    echo "$0 is intentionally unavailable in claude-code-sandboxed" >&2
+    exit 127
+  '';
+
   # Expose only the `node` binary (no npm/npx/corepack) to the claude-code
   # process tree. Required by the openai-codex plugin's companion scripts,
   # which are executed via `node ${CLAUDE_PLUGIN_ROOT}/scripts/*.mjs`.
-  # Omitting npm prevents any `npm install` side effects from the sandbox.
+  # Shadowing npm/npx/corepack with refusing stubs prevents any
+  # `npm install` side effects from the sandbox regardless of what else
+  # is on PATH.
   nodeOnly = runCommand "node-only" { } ''
     mkdir -p $out/bin
     ln -s ${nodejs}/bin/node $out/bin/node
+    for tool in npm npx corepack; do
+      ln -s ${unavailableStub} "$out/bin/$tool"
+    done
   '';
 
   sandboxProfilePath = "\${HOME}/.claude/permissive-open.sb";


### PR DESCRIPTION
  ## Why                                                                                                             
  The `openai-codex` Claude Code plugin could not run inside the `claude-code-sandboxed` wrapper: its hooks need `node` to execute the companion `.mjs` scripts, and the Codex CLI they spawn needs write access to `~/.codex` for its state (`auth.json`, `history.jsonl`, `logs_*.sqlite`, etc.). Both were previously unavailable under the `permissive-open` Seatbelt profile, so `/codex:setup` and related commands failed.                                 
                  
  ## What
  - Add `~/.codex` to the Seatbelt `file-write*` allowlist in `config/agents/permissive-open.sb` so the Codex CLI can persist its state.                                                                                                
  - Fix a regex typo in the same profile: `[C,T]` → `[CT]` (the comma was a literal in the character class, not a separator).                                                                                                        
  - Introduce a `nodeOnly` `runCommand` derivation in `packages/claude-code-sandboxed` that symlinks only the `node` binary from `pkgs.nodejs` (currently LTS 24.x), and prepend it to `PATH` inside the wrapper script. This lets the codex plugin's companion scripts run without exposing `node`/`npm`/`npx` to the user's interactive shell. Omitting `npm`/`npx` also closes off any accidental `npm install` side effects from inside the sandbox.                     
                  