### PR TITLE
Remove Node.js bundling from claude-code-sandboxed

### DIFF
--- a/packages/claude-code-sandboxed/default.nix
+++ b/packages/claude-code-sandboxed/default.nix
@@ -2,37 +2,10 @@
   lib,
   stdenv,
   claude-code,
-  nodejs,
-  runCommand,
-  writeShellScript,
   writeShellScriptBin,
 }:
 
 let
-  # Stub invoked when a package manager command is resolved via the
-  # claude-code-sandboxed PATH. Ensures the "node-only" intent holds even
-  # if another node installation (e.g. Homebrew) exists in the inherited
-  # PATH, because the stub at ${nodeOnly}/bin/{npm,npx,corepack} takes
-  # precedence over any later entry.
-  unavailableStub = writeShellScript "claude-sandbox-unavailable" ''
-    echo "$0 is intentionally unavailable in claude-code-sandboxed" >&2
-    exit 127
-  '';
-
-  # Expose only the `node` binary (no npm/npx/corepack) to the claude-code
-  # process tree. Required by the openai-codex plugin's companion scripts,
-  # which are executed via `node ${CLAUDE_PLUGIN_ROOT}/scripts/*.mjs`.
-  # Shadowing npm/npx/corepack with refusing stubs prevents any
-  # `npm install` side effects from the sandbox regardless of what else
-  # is on PATH.
-  nodeOnly = runCommand "node-only" { } ''
-    mkdir -p $out/bin
-    ln -s ${nodejs}/bin/node $out/bin/node
-    for tool in npm npx corepack; do
-      ln -s ${unavailableStub} "$out/bin/$tool"
-    done
-  '';
-
   sandboxProfilePath = "\${HOME}/.claude/permissive-open.sb";
   errorMessages = {
     profileNotFound = "Error: Sandbox policy not found at ${sandboxProfilePath}";
@@ -43,10 +16,6 @@ let
   claudeWrapper = writeShellScriptBin "claude" ''
     # Direct path to claude-code binary
     CLAUDE_BIN="${claude-code}/bin/claude"
-
-    # Expose only `node` to the claude-code process tree (scoped, not a user
-    # install). Required by the openai-codex plugin's companion scripts.
-    export PATH="${nodeOnly}/bin:$PATH"
 
     # --no-sandbox: bypass sandbox and execute the binary directly.
     # Useful when invoked from an already-sandboxed context (e.g., Gemini CLI).


### PR DESCRIPTION
  ## Why

  The openai-codex plugin for Claude Code is no longer in use, so the
  Node.js runtime that was bundled solely to support its companion scripts
  is now unnecessary dead weight.

  ## What

  - Remove `nodejs`, `runCommand`, and `writeShellScript` dependencies
  - Remove `unavailableStub` (npm/npx/corepack blocking shim)
  - Remove `nodeOnly` derivation (node-only PATH entry)
  - Remove `export PATH="${nodeOnly}/bin:$PATH"` from the wrapper script

  ## References
                                                                         
  - #66 (original PR that added Codex plugin support) 