### PR TITLE
Simplify second-opinion skills and update Codex Serena config

### DIFF
--- a/config/agents/skills/claude-second-opinion/SKILL.md
+++ b/config/agents/skills/claude-second-opinion/SKILL.md
@@ -38,13 +38,13 @@ Then retrieve with `TaskOutput` (`block: true`, `timeout: 120000`).
 **Otherwise** (tmpfile + poll):
 ```bash
 TMPFILE=$(mktemp /tmp/claude-opinion.XXXXXX.log)
-trap "rm -f $TMPFILE" EXIT
 claude --no-sandbox -p "$(cat <<'CLAUDE_PROMPT'
 <constructed prompt>
 CLAUDE_PROMPT
 )" > "$TMPFILE" 2>&1 &
+PID=$!
 ```
-Poll PID every 10-15s. Hard timeout: 300s.
+Poll `$PID` every 10-15s. Hard timeout: 300s. On timeout, `kill $PID` and clean up `$TMPFILE`.
 
 3. Parse output: ignore startup logs, MCP errors, and reasoning traces before the final text. Treat the last plain-text block as the answer.
 
@@ -56,4 +56,4 @@ On any failure — `claude` not found, auth error, network error, or timeout —
 
 ## Shell Escaping
 
-Use a heredoc (`<<'CLAUDE_PROMPT'`) to pass prompts. This avoids shell argument length limits and escaping issues.
+Use a heredoc (`<<'CLAUDE_PROMPT'`) to build prompt text safely. This avoids shell escaping and quoting issues for multi-line content. Note that prompts passed via `-p` are still subject to `ARG_MAX`.

--- a/config/agents/skills/claude-second-opinion/SKILL.md
+++ b/config/agents/skills/claude-second-opinion/SKILL.md
@@ -1,43 +1,18 @@
 ---
 name: claude-second-opinion
-description: "For non-Claude agents only (Codex, Gemini). Get an external second opinion from Claude CLI on a decision with uncertain trade-offs or multiple viable options. Claude agents must use gemini-second-opinion instead."
+description: "Non-Claude agents only. Get an independent second opinion from Claude CLI on decisions with meaningful trade-offs."
 ---
 
 # Claude Second Opinion
 
-Get an alternative perspective from Claude CLI on any decision, design, or code.
+If you are a Claude agent, STOP. Tell the user this skill is for non-Claude agents only.
 
-## Task
+## Steps
 
-0. **Self-Check (CRITICAL)**:
-   - **Are you acting as a Claude agent (Claude Code, Claude CLI)?**
-   - **If YES**: **STOP IMMEDIATELY**. Do not proceed. Consulting yourself is redundant and wasteful. Use `gemini-second-opinion` instead for an external second opinion.
-   - **If NO** (e.g., you are Codex or Gemini): Proceed to step 1.
-
-1. Gather the context for the second opinion:
-   - If `$ARGUMENTS` contains a specific question, use it as-is
-   - If working on code, include relevant file contents or diff
-   - If evaluating a design decision, summarize the options being considered
-2. Construct a prompt and run Claude CLI:
-   ```bash
-   claude --no-sandbox -p "<constructed prompt>"
-   ```
-3. Run Claude CLI using environment-specific handling:
-   - **If running in Codex CLI** (long-running-safe flow):
-     1. Start Claude in background and capture logs to a temp file.
-     2. Save PID and poll every 10-15 seconds.
-     3. Use a hard timeout (default: 300 seconds).
-     4. If timeout is hit, report that Claude is still running and include the latest log tail (do not block indefinitely).
-     5. If process exits non-zero, report failure and include stderr/log tail.
-   - **Otherwise**: run synchronously and wait for result
-4. Present Claude's response alongside your own analysis, highlighting agreements and disagreements
-
-## Prompt Construction
-
-Wrap the context and question for Claude as follows:
+1. Build a concise prompt from `$ARGUMENTS` if provided; otherwise infer the question from the current task context. Keep it focused on decision-relevant information:
 
 ```
-You are providing a second opinion on a technical decision.
+You are providing a second opinion on a decision.
 
 Context:
 <context from the current task>
@@ -48,13 +23,37 @@ Question:
 Provide your independent analysis. If you disagree with the current approach, explain why and suggest alternatives.
 ```
 
-## Rules
+2. Run Claude CLI. Always set `--no-sandbox` (nested sandbox-exec is prohibited on macOS):
 
-- **Claude Agent Restriction**: DO NOT activate or use this skill if you are already a Claude model. Consulting yourself is redundant. This skill is intended for non-Claude agents (like Codex or Gemini) to get a Claude perspective.
-- Always present both your perspective and Claude's perspective
-- Clearly label which opinion comes from which model
-- If Claude's response contradicts your current approach, explain the trade-offs of each approach
-- Do NOT blindly adopt Claude's suggestion - evaluate it critically
-- Keep the Claude prompt focused and under 2000 characters for reliability
-- In Codex CLI, always provide progress updates while polling and avoid silent waits longer than 15 seconds
-- In Codex CLI, do not lose intermediate output: preserve and summarize partial logs on timeout/error
+**If `run_in_background` and `TaskOutput` are available**:
+```bash
+# Bash tool: run_in_background: true, timeout: 120000
+claude --no-sandbox -p "$(cat <<'CLAUDE_PROMPT'
+<constructed prompt>
+CLAUDE_PROMPT
+)" 2>&1
+```
+Then retrieve with `TaskOutput` (`block: true`, `timeout: 120000`).
+
+**Otherwise** (tmpfile + poll):
+```bash
+TMPFILE=$(mktemp /tmp/claude-opinion.XXXXXX.log)
+trap "rm -f $TMPFILE" EXIT
+claude --no-sandbox -p "$(cat <<'CLAUDE_PROMPT'
+<constructed prompt>
+CLAUDE_PROMPT
+)" > "$TMPFILE" 2>&1 &
+```
+Poll PID every 10-15s. Hard timeout: 300s.
+
+3. Parse output: ignore startup logs, MCP errors, and reasoning traces before the final text. Treat the last plain-text block as the answer.
+
+4. Present both perspectives (labeled by model), highlight agreements and disagreements. Evaluate Claude's suggestion critically — do not blindly adopt it.
+
+## Error Handling
+
+On any failure — `claude` not found, auth error, network error, or timeout — report the reason to the user and proceed with your own analysis only. Discard partial output on timeout as unreliable.
+
+## Shell Escaping
+
+Use a heredoc (`<<'CLAUDE_PROMPT'`) to pass prompts. This avoids shell argument length limits and escaping issues.

--- a/config/agents/skills/codex-second-opinion/SKILL.md
+++ b/config/agents/skills/codex-second-opinion/SKILL.md
@@ -1,63 +1,15 @@
 ---
 name: codex-second-opinion
-description: "For non-Codex agents only (Claude, Gemini). Get an independent second opinion from Codex CLI on any decision or question where a second perspective would be valuable. Appropriate triggers: any question with meaningful trade-offs, technical or architectural decisions, comparisons between options. Only invoke when a second perspective would meaningfully change the outcome."
+description: "Non-Codex agents only. Get an independent second opinion from Codex CLI on decisions with meaningful trade-offs."
 ---
 
 # Codex Second Opinion
 
-Get an alternative perspective from Codex CLI on any decision, design, or code.
+If you are a Codex agent, STOP. Tell the user this skill is for non-Codex agents only.
 
-## Task
+## Steps
 
-0. **Self-Check (CRITICAL)**:
-   - **Are you acting as a Codex agent?**
-   - **If YES**: **STOP IMMEDIATELY**. Do not proceed. Consulting yourself is redundant and wasteful. Report to the user that you cannot use this skill as a Codex agent.
-   - **If NO** (e.g., you are Claude or Gemini): Proceed to step 1.
-
-1. Gather the context for the second opinion:
-   - If `$ARGUMENTS` contains a specific question, use it as-is
-   - If working on code, include relevant file contents or diff
-   - If evaluating a design decision, summarize the options being considered
-2. Construct a prompt using the template in the **Prompt Construction** section below
-3. Execute Codex CLI using environment-specific handling:
-   - **If `codex` is not on PATH**: report the missing dependency to the user and skip
-   - **If running in Claude Code** (recommended flow):
-     1. Ensure the `Bash` tool schema is loaded before use (call `ToolSearch` with `query: "select:Bash"` if needed)
-     2. Run Codex in the background with `run_in_background: true` and `timeout: 120000`.
-        Use a heredoc to pass the prompt via stdin (avoids shell argument length limits):
-        ```bash
-        codex -c 'sandbox_mode="danger-full-access"' exec - <<'CODEX_PROMPT'
-        <constructed prompt>
-        CODEX_PROMPT
-        ```
-        The `-c` flag is a global option and must appear before the `exec` subcommand.
-        The value must be a TOML string: `'sandbox_mode="danger-full-access"'` (single quotes wrapping double-quoted value).
-     3. Note the returned `task_id`
-     4. Ensure the `TaskOutput` tool schema is loaded (call `ToolSearch` with `query: "select:TaskOutput"` if needed)
-     5. Retrieve the result with `TaskOutput` using `block: true` and `timeout: 120000`
-     6. Treat the last cohesive text block in the output as Codex's answer; ignore startup logs and MCP messages before it
-   - **If running in Gemini CLI** (long-running-safe flow):
-     1. Start Codex in background and capture logs to a temp file:
-        ```bash
-        codex -c 'sandbox_mode="danger-full-access"' exec - <<'CODEX_PROMPT' > /tmp/codex-opinion.log 2>&1 &
-        <constructed prompt>
-        CODEX_PROMPT
-        ```
-     2. Save PID and poll every 10-15 seconds
-     3. Use a hard timeout (default: 300 seconds)
-     4. If timeout is hit, report that Codex is still running and include the latest log tail (do not block indefinitely)
-     5. If process exits non-zero, report failure and include stderr/log tail
-   - **Otherwise**: run synchronously and wait for result
-     ```bash
-     codex -c 'sandbox_mode="danger-full-access"' exec - <<'CODEX_PROMPT'
-     <constructed prompt>
-     CODEX_PROMPT
-     ```
-4. Present Codex's response alongside your own analysis, highlighting agreements and disagreements
-
-## Prompt Construction
-
-Wrap the context and question for Codex as follows:
+1. Build a concise prompt from `$ARGUMENTS` if provided; otherwise infer the question from the current task context. Keep it focused on decision-relevant information:
 
 ```
 You are providing a second opinion on a decision.
@@ -71,14 +23,35 @@ Question:
 Provide your independent analysis. If you disagree with the current approach, explain why and suggest alternatives.
 ```
 
-## Rules
+2. Run Codex CLI. Always set `sandbox_mode="danger-full-access"` (nested sandbox-exec is prohibited on macOS):
 
-- **Codex Agent Restriction**: DO NOT activate or use this skill if you are already a Codex model. Consulting yourself is redundant. This skill is intended for non-Codex agents (like Claude or Gemini) to get a Codex perspective.
-- Always present both your perspective and Codex's perspective
-- Clearly label which opinion comes from which model
-- If Codex's response contradicts yours, explain the trade-offs of each approach
-- Do NOT blindly adopt Codex's suggestion -- evaluate it critically
-- Keep the Codex prompt focused; very long prompts increase latency
-- In Gemini CLI, always provide progress updates while polling and avoid silent waits longer than 15 seconds
-- In Gemini CLI, do not lose intermediate output: preserve and summarize partial logs on timeout/error
-- Codex CLI output may contain MCP startup logs and reasoning traces before the actual response; treat the final cohesive text block as the answer
+**If `run_in_background` and `TaskOutput` are available**:
+```bash
+# Bash tool: run_in_background: true, timeout: 120000
+codex -c 'sandbox_mode="danger-full-access"' exec - <<'CODEX_PROMPT' 2>&1
+<constructed prompt>
+CODEX_PROMPT
+```
+Then retrieve with `TaskOutput` (`block: true`, `timeout: 120000`).
+
+**Otherwise** (tmpfile + poll):
+```bash
+TMPFILE=$(mktemp /tmp/codex-opinion.XXXXXX.log)
+trap "rm -f $TMPFILE" EXIT
+codex -c 'sandbox_mode="danger-full-access"' exec - <<'CODEX_PROMPT' > "$TMPFILE" 2>&1 &
+<constructed prompt>
+CODEX_PROMPT
+```
+Poll PID every 10-15s. Hard timeout: 300s.
+
+3. Parse output: ignore startup logs, MCP errors, and reasoning traces before the final text. Treat the last plain-text block as the answer.
+
+4. Present both perspectives (labeled by model), highlight agreements and disagreements. Evaluate Codex's suggestion critically — do not blindly adopt it.
+
+## Error Handling
+
+On any failure — `codex` not found, auth error, network error, or timeout — report the reason to the user and proceed with your own analysis only. Discard partial output on timeout as unreliable.
+
+## Shell Escaping
+
+Use a heredoc (`<<'CODEX_PROMPT'`) to pass prompts via stdin. This avoids shell argument length limits and escaping issues.

--- a/config/agents/skills/codex-second-opinion/SKILL.md
+++ b/config/agents/skills/codex-second-opinion/SKILL.md
@@ -37,12 +37,12 @@ Then retrieve with `TaskOutput` (`block: true`, `timeout: 120000`).
 **Otherwise** (tmpfile + poll):
 ```bash
 TMPFILE=$(mktemp /tmp/codex-opinion.XXXXXX.log)
-trap "rm -f $TMPFILE" EXIT
 codex -c 'sandbox_mode="danger-full-access"' exec - <<'CODEX_PROMPT' > "$TMPFILE" 2>&1 &
 <constructed prompt>
 CODEX_PROMPT
+PID=$!
 ```
-Poll PID every 10-15s. Hard timeout: 300s.
+Poll `$PID` every 10-15s. Hard timeout: 300s. On timeout, `kill $PID` and clean up `$TMPFILE`.
 
 3. Parse output: ignore startup logs, MCP errors, and reasoning traces before the final text. Treat the last plain-text block as the answer.
 
@@ -54,4 +54,4 @@ On any failure — `codex` not found, auth error, network error, or timeout — 
 
 ## Shell Escaping
 
-Use a heredoc (`<<'CODEX_PROMPT'`) to pass prompts via stdin. This avoids shell argument length limits and escaping issues.
+Use a heredoc (`<<'CODEX_PROMPT'`) to pass prompts via stdin. This avoids shell escaping and quoting issues. Codex `exec -` reads from stdin, so this is not subject to `ARG_MAX`.

--- a/config/agents/skills/gemini-second-opinion/SKILL.md
+++ b/config/agents/skills/gemini-second-opinion/SKILL.md
@@ -1,51 +1,15 @@
 ---
 name: gemini-second-opinion
-description: "Use this skill (non-Gemini agents only) to get an independent second opinion from Gemini on any decision or question where a second perspective would be valuable. Appropriate triggers: any question with meaningful trade-offs, personal choices, technical or architectural decisions, comparisons between options. Only invoke when a second perspective would meaningfully change the outcome. Runs Gemini CLI in the background."
+description: "Non-Gemini agents only. Get an independent second opinion from Gemini CLI on decisions with meaningful trade-offs."
 ---
 
 # Gemini Second Opinion
 
-Get an alternative perspective from Gemini on any decision, design, or code.
+If you are a Gemini agent, STOP. Tell the user this skill is for non-Gemini agents only.
 
-## Task
+## Steps
 
-0. **Self-Check (CRITICAL)**:
-   - **Are you acting as a Gemini agent?**
-   - **If YES**: **STOP IMMEDIATELY**. Do not proceed. Consulting yourself is redundant and wasteful. Report to the user that you cannot use this skill as a Gemini agent.
-   - **If NO** (e.g., you are Claude): Proceed to step 1.
-
-1. Gather the context for the second opinion:
-   - If `$ARGUMENTS` contains a specific question, use it as-is
-   - If working on code, include relevant file contents or diff
-   - If evaluating a design decision, summarize the options being considered
-2. Construct a prompt using the template in the **Prompt Construction** section below
-3. Execute Gemini CLI using environment-specific handling:
-   - **If `gemini` is not on PATH**: report the missing dependency to the user and skip
-   - **If running in Claude Code** (recommended flow):
-     1. Ensure the `Bash` tool schema is loaded before use (call `ToolSearch` with `query: "select:Bash"` if needed)
-     2. Run Gemini in the background with `run_in_background: true` and `timeout: 60000`:
-        ```bash
-        gemini -p "<constructed prompt>" -o text 2>&1
-        ```
-     3. Note the returned `task_id`
-     4. Ensure the `TaskOutput` tool schema is loaded (call `ToolSearch` with `query: "select:TaskOutput"` if needed)
-     5. Retrieve the result with `TaskOutput` using `block: true` and `timeout: 60000`
-     6. Treat the last cohesive text block in the output as Gemini's answer; ignore startup logs and error traces before it
-   - **If running in Codex CLI** (long-running-safe flow):
-     1. Start Gemini in background and capture logs to a temp file
-     2. Save PID and poll every 10-15 seconds
-     3. Use a hard timeout (default: 300 seconds)
-     4. If timeout is hit, report that Gemini is still running and include the latest log tail (do not block indefinitely)
-     5. If process exits non-zero, report failure and include stderr/log tail
-   - **Otherwise**: run synchronously and wait for result
-     ```bash
-     gemini -p "<constructed prompt>" -o text
-     ```
-4. Present Gemini's response alongside your own analysis, highlighting agreements and disagreements
-
-## Prompt Construction
-
-Wrap the context and question for Gemini as follows:
+1. Build a concise prompt from `$ARGUMENTS` if provided; otherwise infer the question from the current task context. Keep it focused on decision-relevant information:
 
 ```
 You are providing a second opinion on a decision.
@@ -59,14 +23,37 @@ Question:
 Provide your independent analysis. If you disagree with the current approach, explain why and suggest alternatives.
 ```
 
-## Rules
+2. Run Gemini CLI. Always set `GEMINI_SANDBOX=false` (nested sandbox-exec is prohibited on macOS):
 
-- **Gemini Agent Restriction**: DO NOT activate or use this skill if you are already a Gemini model. Consulting yourself is redundant. This skill is intended for non-Gemini agents (like Claude) to get a Gemini perspective.
-- Always present both your perspective and Gemini's perspective
-- Clearly label which opinion comes from which model
-- If Gemini's response contradicts yours, explain the trade-offs of each approach
-- Do NOT blindly adopt Gemini's suggestion — evaluate it critically
-- Keep the Gemini prompt focused; very long prompts increase latency and may hit CLI limits
-- In Codex CLI, always provide progress updates while polling and avoid silent waits longer than 15 seconds
-- In Codex CLI, do not lose intermediate output: preserve and summarize partial logs on timeout/error
-- Gemini CLI output may contain startup logs and onboarding messages before the actual response; treat the final cohesive text block as the answer
+**If `run_in_background` and `TaskOutput` are available**:
+```bash
+# Bash tool: run_in_background: true, timeout: 120000
+GEMINI_SANDBOX=false gemini -p "$(cat <<'GEMINI_PROMPT'
+<constructed prompt>
+GEMINI_PROMPT
+)" -o text 2>&1
+```
+Then retrieve with `TaskOutput` (`block: true`, `timeout: 120000`).
+
+**Otherwise** (tmpfile + poll):
+```bash
+TMPFILE=$(mktemp /tmp/gemini-opinion.XXXXXX.log)
+trap "rm -f $TMPFILE" EXIT
+GEMINI_SANDBOX=false gemini -p "$(cat <<'GEMINI_PROMPT'
+<constructed prompt>
+GEMINI_PROMPT
+)" -o text > "$TMPFILE" 2>&1 &
+```
+Poll PID every 10-15s. Hard timeout: 300s.
+
+3. Parse output: ignore startup logs, MCP errors, and reasoning traces before the final text. Treat the last plain-text block as the answer.
+
+4. Present both perspectives (labeled by model), highlight agreements and disagreements. Evaluate Gemini's suggestion critically — do not blindly adopt it.
+
+## Error Handling
+
+On any failure — `gemini` not found, auth error (`ADC must be`, `gcloud.auth`), network error, or timeout — report the reason to the user and proceed with your own analysis only. Discard partial output on timeout as unreliable.
+
+## Shell Escaping
+
+Use a heredoc to pass prompts. This avoids shell argument length limits and escaping issues.

--- a/config/agents/skills/gemini-second-opinion/SKILL.md
+++ b/config/agents/skills/gemini-second-opinion/SKILL.md
@@ -38,13 +38,13 @@ Then retrieve with `TaskOutput` (`block: true`, `timeout: 120000`).
 **Otherwise** (tmpfile + poll):
 ```bash
 TMPFILE=$(mktemp /tmp/gemini-opinion.XXXXXX.log)
-trap "rm -f $TMPFILE" EXIT
 GEMINI_SANDBOX=false gemini -p "$(cat <<'GEMINI_PROMPT'
 <constructed prompt>
 GEMINI_PROMPT
 )" -o text > "$TMPFILE" 2>&1 &
+PID=$!
 ```
-Poll PID every 10-15s. Hard timeout: 300s.
+Poll `$PID` every 10-15s. Hard timeout: 300s. On timeout, `kill $PID` and clean up `$TMPFILE`.
 
 3. Parse output: ignore startup logs, MCP errors, and reasoning traces before the final text. Treat the last plain-text block as the answer.
 
@@ -56,4 +56,4 @@ On any failure — `gemini` not found, auth error (`ADC must be`, `gcloud.auth`)
 
 ## Shell Escaping
 
-Use a heredoc to pass prompts. This avoids shell argument length limits and escaping issues.
+Use a heredoc to build prompt text safely. This avoids shell escaping and quoting issues for multi-line content. Note that prompts passed via `-p` are still subject to `ARG_MAX`.

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -46,4 +46,4 @@ args = [
 ]
 
 [mcp_servers.serena.env]
-SERENA_HOME = "${PWD}/.serena"
+SERENA_HOME = ".serena"

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -33,8 +33,17 @@ tool_timeout_sec = 120
 
 [mcp_servers.serena]
 type = "stdio"
-command = "sh"
+command = "serena"
 args = [
-    "-c",
-    "SERENA_HOME=\"$PWD/.serena\" exec serena start-mcp-server --context codex --project-from-cwd --open-web-dashboard False",
+    "start-mcp-server",
+    "--context",
+    "codex",
+    "--project-from-cwd",
+    "--enable-web-dashboard",
+    "False",
+    "--enable-gui-log-window",
+    "False",
 ]
+
+[mcp_servers.serena.env]
+SERENA_HOME = "${PWD}/.serena"

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1775839657,
+        "narHash": "sha256-SPm9ck7jh3Un9nwPuMGbRU04UroFmOHjLP56T10MOeM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "7cf72d978629469c4bd4206b95c402514c1f6000",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "fenix": {
       "inputs": {
         "nixpkgs": [
@@ -321,16 +336,17 @@
     },
     "voicevox-cli": {
       "inputs": {
+        "crane": "crane",
         "fenix": "fenix",
         "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1773035670,
-        "narHash": "sha256-Li6onNOkhdwgwq6lX65Pm6zUY7u7YdSLipm0Z+nJlFY=",
+        "lastModified": 1776141552,
+        "narHash": "sha256-eLljj6S9SH5unr1IlE+FKipqnWgZ/zlyC+M4mnjvzjc=",
         "owner": "usabarashi",
         "repo": "voicevox-cli",
-        "rev": "f3c2e42ac79998901b46e9c38135285c95666f64",
+        "rev": "388137ee59f81d037c82034f543f5f442054b0c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
  ## Why

  The three second-opinion skill files (Claude, Codex, Gemini) had grown verbose with per-environment branching logic and redundant rules. This consolidates them into a shared structure that is easier to maintain. The Codex Serena MCP config is also cleaned up to invoke `serena` directly instead of wrapping it in `sh -c`.

  ## What

  - Streamline claude/codex/gemini second-opinion SKILL.md files: shorter descriptions, unified step structure, dedicated error-handling and shell-escaping sections, remove verbose per-agent branching
  - Replace `sh -c` wrapper in Codex `config.toml` with direct `serena` invocation and explicit `[mcp_servers.serena.env]` block
  - Update `flake.lock`: bump voicevox-cli (adds crane input)
