### PR TITLE
Align Gemini CLI Serena MCP options with Codex CLI

### DIFF
--- a/config/gemini/settings.json
+++ b/config/gemini/settings.json
@@ -34,11 +34,13 @@
         "--context",
         "ide",
         "--project-from-cwd",
-        "--open-web-dashboard",
+        "--enable-web-dashboard",
+        "False",
+        "--enable-gui-log-window",
         "False"
       ],
       "env": {
-        "SERENA_HOME": "${PWD}/.serena"
+        "SERENA_HOME": ".serena"
       }
     }
   },


### PR DESCRIPTION
  ## Why

  The Gemini CLI Serena MCP server config used different flag names and was missing options compared to the Codex CLI config. This unifies the settings across agents for consistency and maintainability.

  ## What

  - Rename `--open-web-dashboard` to `--enable-web-dashboard` to match flag naming                    
  - Add `--enable-gui-log-window False` to explicitly disable the GUI log window
  - Simplify `SERENA_HOME` from `${PWD}/.serena` to `.serena`
