### PR TITLE
Fetch claude-code binary directly from GCS for faster version updates

### DIFF
--- a/packages/claude-code-sandboxed/default.nix
+++ b/packages/claude-code-sandboxed/default.nix
@@ -1,33 +1,78 @@
+# Sandboxed Claude Code CLI with pre-built binary.
+# Binary is fetched from Google Cloud Storage, managed independently from nixpkgs.
+# Requires --impure flag for builtins.fetchurl (no hash verification).
+#
+# Update workflow: update `version` below, then deploy.
 {
   lib,
-  stdenv,
-  claude-code,
-  writeShellScriptBin,
+  stdenvNoCC,
+  makeBinaryWrapper,
+  procps,
+  ripgrep,
 }:
-
 let
+  stdenv = stdenvNoCC;
+  version = "2.1.112";
+  baseUrl = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
+  platformKey = "${stdenv.hostPlatform.node.platform}-${stdenv.hostPlatform.node.arch}";
+
   sandboxProfilePath = "\${HOME}/.claude/permissive-open.sb";
   errorMessages = {
     profileNotFound = "Error: Sandbox policy not found at ${sandboxProfilePath}";
     installationNote = "Please ensure claude configuration is properly installed.";
   };
-  sandboxNotice = "🔒 Running Claude Code with macOS Seatbelt (permissive-open)";
+  sandboxNotice = "Running Claude Code with macOS Seatbelt (permissive-open)";
+in
+stdenv.mkDerivation {
+  pname = "claude-code-sandboxed";
+  inherit version;
 
-  claudeWrapper = writeShellScriptBin "claude" ''
-    # Direct path to claude-code binary
-    CLAUDE_BIN="${claude-code}/bin/claude"
+  src = builtins.fetchurl "${baseUrl}/${version}/${platformKey}/claude";
+
+  dontUnpack = true;
+  dontBuild = true;
+  __noChroot = stdenv.hostPlatform.isDarwin;
+  dontStrip = true;
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  strictDeps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # Install the binary as claude-unwrapped
+    install -Dm755 $src $out/bin/claude-unwrapped
+
+    # Wrap with environment variables
+    wrapProgram $out/bin/claude-unwrapped \
+      --set DISABLE_AUTOUPDATER 1 \
+      --set-default FORCE_AUTOUPDATE_PLUGINS 1 \
+      --set DISABLE_INSTALLATION_CHECKS 1 \
+      --set USE_BUILTIN_RIPGREP 0 \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          procps
+          ripgrep
+        ]
+      }
+
+    # Create sandbox wrapper script
+    cat > $out/bin/claude <<'WRAPPER'
+    #!/usr/bin/env bash
+    CLAUDE_BIN="CLAUDE_BIN_PLACEHOLDER"
 
     # --no-sandbox: bypass sandbox and execute the binary directly.
-    # Useful when invoked from an already-sandboxed context (e.g., Gemini CLI).
     if [ "''${1:-}" = "--no-sandbox" ]; then
         shift
         exec "$CLAUDE_BIN" "$@"
     fi
 
     # Check if sandbox profile exists
-    if [ ! -f "${sandboxProfilePath}" ]; then
-        echo "${errorMessages.profileNotFound}" >&2
-        echo "${errorMessages.installationNote}" >&2
+    SANDBOX_PROFILE="SANDBOX_PROFILE_PLACEHOLDER"
+    if [ ! -f "$SANDBOX_PROFILE" ]; then
+        echo "PROFILE_NOT_FOUND_PLACEHOLDER" >&2
+        echo "INSTALLATION_NOTE_PLACEHOLDER" >&2
         exit 1
     fi
 
@@ -35,41 +80,31 @@ let
     case "$*" in
         *--version*|*--help*|*-h*) ;;
         *)
-            echo "${sandboxNotice}" >&2
+            echo "SANDBOX_NOTICE_PLACEHOLDER" >&2
             ;;
     esac
 
     # Execute claude with sandbox
-    exec /usr/bin/sandbox-exec -f "${sandboxProfilePath}" -D TARGET_DIR="$(pwd)" -D HOME_DIR="$HOME" "$CLAUDE_BIN" "$@"
-  '';
+    exec /usr/bin/sandbox-exec -f "$SANDBOX_PROFILE" -D TARGET_DIR="$(pwd)" -D HOME_DIR="$HOME" "$CLAUDE_BIN" "$@"
+    WRAPPER
+    chmod +x $out/bin/claude
 
-in
-stdenv.mkDerivation {
-  pname = "claude-code-sandboxed";
-  version = claude-code.version or "1.0.0";
-
-  dontUnpack = true;
-  dontBuild = true;
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/bin
-    ln -s ${claudeWrapper}/bin/claude $out/bin/claude
+    substituteInPlace $out/bin/claude \
+      --replace-fail 'CLAUDE_BIN_PLACEHOLDER' "$out/bin/claude-unwrapped" \
+      --replace-fail 'SANDBOX_PROFILE_PLACEHOLDER' '${sandboxProfilePath}' \
+      --replace-fail 'PROFILE_NOT_FOUND_PLACEHOLDER' '${errorMessages.profileNotFound}' \
+      --replace-fail 'INSTALLATION_NOTE_PLACEHOLDER' '${errorMessages.installationNote}' \
+      --replace-fail 'SANDBOX_NOTICE_PLACEHOLDER' '${sandboxNotice}'
 
     runHook postInstall
   '';
 
-  meta = with lib; {
-    description = "Sandboxed wrapper for Claude Code CLI";
-    longDescription = ''
-      A security wrapper that runs claude-code within a macOS sandbox using sandbox-exec
-      to restrict file system access for improved security.
-
-      Note: Requires claude-code to be installed separately.
-    '';
-    license = licenses.mit;
-    platforms = platforms.darwin;
+  meta = {
+    description = "Sandboxed Claude Code CLI with pre-built binary";
+    homepage = "https://github.com/anthropics/claude-code";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [ "aarch64-darwin" ];
     mainProgram = "claude";
   };
 }

--- a/packages/claude-code-sandboxed/default.nix
+++ b/packages/claude-code-sandboxed/default.nix
@@ -6,105 +6,66 @@
 {
   lib,
   stdenvNoCC,
-  makeBinaryWrapper,
+  writeShellScriptBin,
   procps,
   ripgrep,
 }:
 let
-  stdenv = stdenvNoCC;
   version = "2.1.112";
   baseUrl = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
-  platformKey = "${stdenv.hostPlatform.node.platform}-${stdenv.hostPlatform.node.arch}";
+  platformKey = "${stdenvNoCC.hostPlatform.node.platform}-${stdenvNoCC.hostPlatform.node.arch}";
+
+  claudeBin = stdenvNoCC.mkDerivation {
+    pname = "claude-code-bin";
+    inherit version;
+    src = builtins.fetchurl "${baseUrl}/${version}/${platformKey}/claude";
+    dontUnpack = true;
+    dontBuild = true;
+    dontStrip = true;
+    __noChroot = stdenvNoCC.hostPlatform.isDarwin;
+    installPhase = "install -Dm755 $src $out/bin/claude";
+    meta = {
+      license = lib.licenses.unfree;
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      platforms = [ "aarch64-darwin" ];
+    };
+  };
 
   sandboxProfilePath = "\${HOME}/.claude/permissive-open.sb";
-  errorMessages = {
-    profileNotFound = "Error: Sandbox policy not found at ${sandboxProfilePath}";
-    installationNote = "Please ensure claude configuration is properly installed.";
-  };
-  sandboxNotice = "Running Claude Code with macOS Seatbelt (permissive-open)";
 in
-stdenv.mkDerivation {
-  pname = "claude-code-sandboxed";
-  inherit version;
+writeShellScriptBin "claude" ''
+  export DISABLE_AUTOUPDATER=1
+  export FORCE_AUTOUPDATE_PLUGINS=1
+  export DISABLE_INSTALLATION_CHECKS=1
+  export USE_BUILTIN_RIPGREP=0
+  export PATH="${
+    lib.makeBinPath [
+      procps
+      ripgrep
+    ]
+  }:$PATH"
 
-  src = builtins.fetchurl "${baseUrl}/${version}/${platformKey}/claude";
+  CLAUDE_BIN="${claudeBin}/bin/claude"
 
-  dontUnpack = true;
-  dontBuild = true;
-  __noChroot = stdenv.hostPlatform.isDarwin;
-  dontStrip = true;
+  # --no-sandbox: bypass sandbox and execute the binary directly.
+  # Useful when invoked from an already-sandboxed context (e.g., Gemini CLI).
+  if [ "''${1:-}" = "--no-sandbox" ]; then
+      shift
+      exec "$CLAUDE_BIN" "$@"
+  fi
 
-  nativeBuildInputs = [ makeBinaryWrapper ];
+  if [ ! -f "${sandboxProfilePath}" ]; then
+      echo "Error: Sandbox policy not found at ${sandboxProfilePath}" >&2
+      echo "Please ensure claude configuration is properly installed." >&2
+      exit 1
+  fi
 
-  strictDeps = true;
+  case "$*" in
+      *--version*|*--help*|*-h*) ;;
+      *)
+          echo "Running Claude Code with macOS Seatbelt (permissive-open)" >&2
+          ;;
+  esac
 
-  installPhase = ''
-    runHook preInstall
-
-    # Install the binary as claude-unwrapped
-    install -Dm755 $src $out/bin/claude-unwrapped
-
-    # Wrap with environment variables
-    wrapProgram $out/bin/claude-unwrapped \
-      --set DISABLE_AUTOUPDATER 1 \
-      --set-default FORCE_AUTOUPDATE_PLUGINS 1 \
-      --set DISABLE_INSTALLATION_CHECKS 1 \
-      --set USE_BUILTIN_RIPGREP 0 \
-      --prefix PATH : ${
-        lib.makeBinPath [
-          procps
-          ripgrep
-        ]
-      }
-
-    # Create sandbox wrapper script
-    cat > $out/bin/claude <<'WRAPPER'
-    #!/usr/bin/env bash
-    CLAUDE_BIN="CLAUDE_BIN_PLACEHOLDER"
-
-    # --no-sandbox: bypass sandbox and execute the binary directly.
-    if [ "''${1:-}" = "--no-sandbox" ]; then
-        shift
-        exec "$CLAUDE_BIN" "$@"
-    fi
-
-    # Check if sandbox profile exists
-    SANDBOX_PROFILE="SANDBOX_PROFILE_PLACEHOLDER"
-    if [ ! -f "$SANDBOX_PROFILE" ]; then
-        echo "PROFILE_NOT_FOUND_PLACEHOLDER" >&2
-        echo "INSTALLATION_NOTE_PLACEHOLDER" >&2
-        exit 1
-    fi
-
-    # Show sandbox mode if not using --version or help flags
-    case "$*" in
-        *--version*|*--help*|*-h*) ;;
-        *)
-            echo "SANDBOX_NOTICE_PLACEHOLDER" >&2
-            ;;
-    esac
-
-    # Execute claude with sandbox
-    exec /usr/bin/sandbox-exec -f "$SANDBOX_PROFILE" -D TARGET_DIR="$(pwd)" -D HOME_DIR="$HOME" "$CLAUDE_BIN" "$@"
-    WRAPPER
-    chmod +x $out/bin/claude
-
-    substituteInPlace $out/bin/claude \
-      --replace-fail 'CLAUDE_BIN_PLACEHOLDER' "$out/bin/claude-unwrapped" \
-      --replace-fail 'SANDBOX_PROFILE_PLACEHOLDER' '${sandboxProfilePath}' \
-      --replace-fail 'PROFILE_NOT_FOUND_PLACEHOLDER' '${errorMessages.profileNotFound}' \
-      --replace-fail 'INSTALLATION_NOTE_PLACEHOLDER' '${errorMessages.installationNote}' \
-      --replace-fail 'SANDBOX_NOTICE_PLACEHOLDER' '${sandboxNotice}'
-
-    runHook postInstall
-  '';
-
-  meta = {
-    description = "Sandboxed Claude Code CLI with pre-built binary";
-    homepage = "https://github.com/anthropics/claude-code";
-    license = lib.licenses.unfree;
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    platforms = [ "aarch64-darwin" ];
-    mainProgram = "claude";
-  };
-}
+  exec /usr/bin/sandbox-exec -f "${sandboxProfilePath}" -D TARGET_DIR="$(pwd)" -D HOME_DIR="$HOME" "$CLAUDE_BIN" "$@"
+''

--- a/packages/claude-code-sandboxed/default.nix
+++ b/packages/claude-code-sandboxed/default.nix
@@ -13,7 +13,7 @@
 let
   version = "2.1.112";
   baseUrl = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
-  platformKey = "${stdenvNoCC.hostPlatform.node.platform}-${stdenvNoCC.hostPlatform.node.arch}";
+  platformKey = "darwin-arm64";
 
   claudeBin = stdenvNoCC.mkDerivation {
     pname = "claude-code-bin";
@@ -22,7 +22,6 @@ let
     dontUnpack = true;
     dontBuild = true;
     dontStrip = true;
-    __noChroot = stdenvNoCC.hostPlatform.isDarwin;
     installPhase = "install -Dm755 $src $out/bin/claude";
     meta = {
       license = lib.licenses.unfree;
@@ -60,8 +59,8 @@ writeShellScriptBin "claude" ''
       exit 1
   fi
 
-  case "$*" in
-      *--version*|*--help*|*-h*) ;;
+  case " $* " in
+      *" --version "*|*" --help "*|*" -h "*) ;;
       *)
           echo "Running Claude Code with macOS Seatbelt (permissive-open)" >&2
           ;;


### PR DESCRIPTION
  ## Why
  nixpkgs-unstable tracks claude-code slower than upstream (e.g. nixpkgs is on 2.1.87 while upstream is already on 2.1.112), which blocks timely adoption of fixes and new features. Fetching the pre-built binary from the same GCS bucket that nixpkgs' `claude-code-bin` and the official Homebrew cask already use lets us update independently from the nixpkgs release cycle by changing just one `version` string (`--impure` is already required by the deploy apps, so there is no new operational cost).

  ## What
  - Replace the `claude-code` nixpkgs dependency with an inline `claudeBin` derivation that `builtins.fetchurl`s the pre-built native binary for `darwin-arm64`
  - Pin the current version to `2.1.112`; future bumps only require editing the `version` string                                                          
  - Collapse the previous two-level wrapper (`claude` → `claude-unwrapped` via `wrapProgram` → binary) into a single `writeShellScriptBin` that exports the required env vars (`DISABLE_AUTOUPDATER`, `FORCE_AUTOUPDATE_PLUGINS`, `DISABLE_INSTALLATION_CHECKS`, `USE_BUILTIN_RIPGREP`), prepends `procps` / `ripgrep` to `PATH`, and invokes `sandbox-exec`                                                                                                         
  - Preserve existing sandbox behavior, including the `--no-sandbox` bypass for already-sandboxed contexts (e.g. Gemini CLI)
  - Tighten the help/version detection (`" --version "` / `" --help "` / `" -h "` whole-token match) so arguments that merely contain `-h` as a substring don't suppress the sandbox notice
  - Drop the emoji from the sandbox notice; update `meta` (unfree license, `binaryNativeCode` provenance, `aarch64-darwin`-only)
  - Hardcode `platformKey = "darwin-arm64"` instead of relying on the undocumented `hostPlatform.node.{platform,arch}` attributes (matches `meta.platforms`)
  Update workflow going forward: bump the `version` string in `packages/claude-code-sandboxed/default.nix` and redeploy with `nix run .#<host>`.
