### PR TITLE
Harden second-opinion skills: tempfile output + MCP isolation

### DIFF
--- a/config/agents/skills/codex-second-opinion/SKILL.md
+++ b/config/agents/skills/codex-second-opinion/SKILL.md
@@ -25,33 +25,28 @@ Provide your independent analysis. If you disagree with the current approach, ex
 
 2. Run Codex CLI. Always set `sandbox_mode="danger-full-access"` (nested sandbox-exec is prohibited on macOS):
 
+**Pre-choose the output path yourself** (used by both code branches below). Pick a unique literal filesystem path in advance — e.g., `/tmp/codex-opinion-<unix-timestamp>-<random>.log`, assembled in your working context (not via `mktemp` inside the snippet, because that binds the path to a shell variable you cannot retrieve later). Reuse the exact same literal path verbatim in the Bash invocation and in the follow-up `Read`. This avoids any dependency on a harness-specific output-capture tool (`BashOutput`, task output files, etc.).
+
 **If Bash supports `run_in_background: true`** (typical case):
 ```bash
-# Bash tool: run_in_background: true, timeout: 120000
-# Echo the tempfile path so it is retrievable via BashOutput;
-# Codex output itself is redirected to the file.
-TMPFILE=$(mktemp /tmp/codex-opinion.XXXXXX.log)
-echo "TMPFILE=$TMPFILE"
-codex -c 'sandbox_mode="danger-full-access"' exec - > "$TMPFILE" 2>&1 <<'CODEX_PROMPT'
+# Bash tool: run_in_background: true, timeout: 300000
+# Substitute <TMPFILE> with the literal path you chose above.
+codex -c 'sandbox_mode="danger-full-access"' exec - > <TMPFILE> 2>&1 <<'CODEX_PROMPT'
 <constructed prompt>
 CODEX_PROMPT
-echo "EXIT=$?"
 ```
-Retrieve in two steps: (a) `BashOutput` with the returned `shell_id` — use it to capture the echoed `TMPFILE=...` path and to confirm completion via the `EXIT=` line; it will NOT contain Codex's output because stdout/stderr are redirected to the file. (b) `Read` the concrete `TMPFILE` path for the actual answer. After reading, delete the file with `rm "<tmpfile>"` (keep it only when debugging). `TaskOutput` is for Agent/Task tool tasks — do not use it here.
+Wait for the background task to finish, then `Read <TMPFILE>`. Do NOT add `sleep` / `kill -0` / `pgrep` poll loops — they burn tool-call budget and the harness's completion signal is authoritative. An interim `Read` "to peek at progress" is also unnecessary; the file is incomplete until Codex exits. **If you are a nested subagent** (running inside an Agent/Task tool), do NOT use this background path — a subagent that ends its turn while Codex is still running will lose the background task. Use the foreground fallback below instead. After reading, `rm <TMPFILE>`; if the harness denies `rm`, leave the file — `/tmp` is reclaimed by the OS. `TaskOutput` is for Agent/Task tool tasks — do not use it here.
 
-**If `run_in_background` is unavailable** (foreground-only environment, last resort):
+**Foreground fallback** (use when `run_in_background` is unavailable, OR when you are a nested subagent):
 ```bash
-TMPFILE=$(mktemp /tmp/codex-opinion.XXXXXX.log)
-echo "TMPFILE=$TMPFILE"
-codex -c 'sandbox_mode="danger-full-access"' exec - <<'CODEX_PROMPT' > "$TMPFILE" 2>&1 &
+# Bash tool: timeout: 300000
+codex -c 'sandbox_mode="danger-full-access"' exec - > <TMPFILE> 2>&1 <<'CODEX_PROMPT'
 <constructed prompt>
 CODEX_PROMPT
-PID=$!
-echo "PID=$PID"
 ```
-Capture the echoed `TMPFILE` and `PID` from the foreground output; subsequent tool calls need the concrete values. Poll with `kill -0 <PID>` every 10-15s. Hard timeout: 300s. On timeout, `kill <PID>` and `rm <TMPFILE>`. On success, `Read <TMPFILE>` then `rm <TMPFILE>`. Do NOT use `trap 'rm -f $TMPFILE' EXIT` in the launching shell — the trap fires when that Bash invocation exits, deleting the file before the background process writes to it.
+Bash blocks until Codex finishes or the tool timeout fires. On return, `Read <TMPFILE>` and then `rm <TMPFILE>`. Do not use `&` + `$!` polling — it adds PID tracking for no benefit once you control the Bash tool timeout. Do NOT use `trap 'rm -f $TMPFILE' EXIT` in any snippet that backgrounds a process — the trap fires when the launching shell exits, deleting the file before the background process writes to it.
 
-3. Parse output: ignore startup logs, MCP errors, reasoning traces, and trailing metadata (`tokens used`, `session id`, token summary lines). Treat the last substantive plain-text block before those metadata lines as the answer. If the same answer appears twice (once inline, once echoed after metadata), take either occurrence — they are equivalent.
+3. Parse output: ignore startup logs, MCP registration/errors, **MCP tool-call traces** (e.g. `voicevox.text_to_speech`, `serena.find_symbol` — any inline JSON or tool invocation lines from the caller's MCP context leaking into Codex's output, including cases where Codex itself invokes an MCP tool mid-reasoning), reasoning traces, and trailing metadata (`tokens used`, `session id`, token summary). The substantive answer is the main plain-text block; Codex sometimes prints it once inline and echoes it again after metadata. **Tiebreaker when both copies are complete: use the post-metadata echo** — it is Codex's canonical final form.
 
 4. Present both perspectives (labeled by model), highlight agreements and disagreements. Evaluate Codex's suggestion critically — do not blindly adopt it.
 

--- a/config/agents/skills/codex-second-opinion/SKILL.md
+++ b/config/agents/skills/codex-second-opinion/SKILL.md
@@ -25,16 +25,18 @@ Provide your independent analysis. If you disagree with the current approach, ex
 
 2. Run Codex CLI. Always set `sandbox_mode="danger-full-access"` (nested sandbox-exec is prohibited on macOS):
 
-**If `run_in_background` and `TaskOutput` are available**:
+**If Bash supports `run_in_background: true`** (typical case):
 ```bash
 # Bash tool: run_in_background: true, timeout: 120000
-codex -c 'sandbox_mode="danger-full-access"' exec - <<'CODEX_PROMPT' 2>&1
+# Redirect output to a file so it survives regardless of BashOutput availability.
+TMPFILE=$(mktemp /tmp/codex-opinion.XXXXXX.log)
+codex -c 'sandbox_mode="danger-full-access"' exec - > "$TMPFILE" 2>&1 <<'CODEX_PROMPT'
 <constructed prompt>
 CODEX_PROMPT
 ```
-Then retrieve with `TaskOutput` (`block: true`, `timeout: 120000`).
+Wait for completion, then retrieve output. Preferred: `BashOutput` with the returned `shell_id`. If `BashOutput` is not exposed in your environment, `Read` the `$TMPFILE` directly. `TaskOutput` is for Agent/Task tool tasks — do not use it here.
 
-**Otherwise** (tmpfile + poll):
+**If `run_in_background` is unavailable** (foreground-only environment, last resort):
 ```bash
 TMPFILE=$(mktemp /tmp/codex-opinion.XXXXXX.log)
 codex -c 'sandbox_mode="danger-full-access"' exec - <<'CODEX_PROMPT' > "$TMPFILE" 2>&1 &
@@ -44,7 +46,7 @@ PID=$!
 ```
 Poll `$PID` every 10-15s. Hard timeout: 300s. On timeout, `kill $PID` and clean up `$TMPFILE`.
 
-3. Parse output: ignore startup logs, MCP errors, and reasoning traces before the final text. Treat the last plain-text block as the answer.
+3. Parse output: ignore startup logs, MCP errors, reasoning traces, and trailing metadata (`tokens used`, `session id`, token summary lines). Treat the last substantive plain-text block before those metadata lines as the answer. If the same answer appears twice (once inline, once echoed after metadata), take either occurrence — they are equivalent.
 
 4. Present both perspectives (labeled by model), highlight agreements and disagreements. Evaluate Codex's suggestion critically — do not blindly adopt it.
 

--- a/config/agents/skills/codex-second-opinion/SKILL.md
+++ b/config/agents/skills/codex-second-opinion/SKILL.md
@@ -28,23 +28,28 @@ Provide your independent analysis. If you disagree with the current approach, ex
 **If Bash supports `run_in_background: true`** (typical case):
 ```bash
 # Bash tool: run_in_background: true, timeout: 120000
-# Redirect output to a file so it survives regardless of BashOutput availability.
+# Echo the tempfile path so it is retrievable via BashOutput;
+# Codex output itself is redirected to the file.
 TMPFILE=$(mktemp /tmp/codex-opinion.XXXXXX.log)
+echo "TMPFILE=$TMPFILE"
 codex -c 'sandbox_mode="danger-full-access"' exec - > "$TMPFILE" 2>&1 <<'CODEX_PROMPT'
 <constructed prompt>
 CODEX_PROMPT
+echo "EXIT=$?"
 ```
-Wait for completion, then retrieve output. Preferred: `BashOutput` with the returned `shell_id`. If `BashOutput` is not exposed in your environment, `Read` the `$TMPFILE` directly. `TaskOutput` is for Agent/Task tool tasks — do not use it here.
+Retrieve in two steps: (a) `BashOutput` with the returned `shell_id` — use it to capture the echoed `TMPFILE=...` path and to confirm completion via the `EXIT=` line; it will NOT contain Codex's output because stdout/stderr are redirected to the file. (b) `Read` the concrete `TMPFILE` path for the actual answer. After reading, delete the file with `rm "<tmpfile>"` (keep it only when debugging). `TaskOutput` is for Agent/Task tool tasks — do not use it here.
 
 **If `run_in_background` is unavailable** (foreground-only environment, last resort):
 ```bash
 TMPFILE=$(mktemp /tmp/codex-opinion.XXXXXX.log)
+echo "TMPFILE=$TMPFILE"
 codex -c 'sandbox_mode="danger-full-access"' exec - <<'CODEX_PROMPT' > "$TMPFILE" 2>&1 &
 <constructed prompt>
 CODEX_PROMPT
 PID=$!
+echo "PID=$PID"
 ```
-Poll `$PID` every 10-15s. Hard timeout: 300s. On timeout, `kill $PID` and clean up `$TMPFILE`.
+Capture the echoed `TMPFILE` and `PID` from the foreground output; subsequent tool calls need the concrete values. Poll with `kill -0 <PID>` every 10-15s. Hard timeout: 300s. On timeout, `kill <PID>` and `rm <TMPFILE>`. On success, `Read <TMPFILE>` then `rm <TMPFILE>`. Do NOT use `trap 'rm -f $TMPFILE' EXIT` in the launching shell — the trap fires when that Bash invocation exits, deleting the file before the background process writes to it.
 
 3. Parse output: ignore startup logs, MCP errors, reasoning traces, and trailing metadata (`tokens used`, `session id`, token summary lines). Treat the last substantive plain-text block before those metadata lines as the answer. If the same answer appears twice (once inline, once echoed after metadata), take either occurrence — they are equivalent.
 

--- a/config/agents/skills/gemini-second-opinion/SKILL.md
+++ b/config/agents/skills/gemini-second-opinion/SKILL.md
@@ -31,24 +31,30 @@ Provide your independent analysis. If you disagree with the current approach, ex
 **If Bash supports `run_in_background: true`** (typical case):
 ```bash
 # Bash tool: run_in_background: true, timeout: 120000
+# Echo the tempfile path so it is retrievable via BashOutput;
+# Gemini output itself is redirected to the file.
 TMPFILE=$(mktemp /tmp/gemini-opinion.XXXXXX.log)
+echo "TMPFILE=$TMPFILE"
 GEMINI_SANDBOX=false gemini --allowed-mcp-server-names "" -e "" -p "$(cat <<'GEMINI_PROMPT'
 <constructed prompt>
 GEMINI_PROMPT
 )" -o text > "$TMPFILE" 2>&1
+echo "EXIT=$?"
 ```
-Wait for completion, then retrieve output. Preferred: `BashOutput` with the returned `shell_id`. If `BashOutput` is not exposed in your environment, `Read` the `$TMPFILE` directly. `TaskOutput` is for Agent/Task tool tasks — do not use it here.
+Retrieve in two steps: (a) `BashOutput` with the returned `shell_id` — use it to capture the echoed `TMPFILE=...` path and to confirm completion via the `EXIT=` line; it will NOT contain Gemini's output because stdout/stderr are redirected to the file. (b) `Read` the concrete `TMPFILE` path for the actual answer. After reading, delete the file with `rm "<tmpfile>"` (keep it only when debugging). `TaskOutput` is for Agent/Task tool tasks — do not use it here.
 
 **If `run_in_background` is unavailable** (foreground-only environment, last resort):
 ```bash
 TMPFILE=$(mktemp /tmp/gemini-opinion.XXXXXX.log)
+echo "TMPFILE=$TMPFILE"
 GEMINI_SANDBOX=false gemini --allowed-mcp-server-names "" -e "" -p "$(cat <<'GEMINI_PROMPT'
 <constructed prompt>
 GEMINI_PROMPT
 )" -o text > "$TMPFILE" 2>&1 &
 PID=$!
+echo "PID=$PID"
 ```
-Poll `$PID` every 10-15s. Hard timeout: 300s. On timeout, `kill $PID` and clean up `$TMPFILE`.
+Capture the echoed `TMPFILE` and `PID` from the foreground output; subsequent tool calls need the concrete values. Poll with `kill -0 <PID>` every 10-15s. Hard timeout: 300s. On timeout, `kill <PID>` and `rm <TMPFILE>`. On success, `Read <TMPFILE>` then `rm <TMPFILE>`. Do NOT use `trap 'rm -f $TMPFILE' EXIT` in the launching shell — the trap fires when that Bash invocation exits, deleting the file before the background process writes to it.
 
 3. Parse output: ignore startup logs, MCP registration/tool-call errors (these may appear inline mid-output, not just before the answer), reasoning traces, and persona/voice styling leaked from the caller's MCP context (e.g. a voicevox persona bleeding into Gemini's reply). Treat the final substantive plain-text block as the answer. If it arrives in a persona voice, extract the content and present it in neutral prose.
 

--- a/config/agents/skills/gemini-second-opinion/SKILL.md
+++ b/config/agents/skills/gemini-second-opinion/SKILL.md
@@ -23,22 +23,26 @@ Question:
 Provide your independent analysis. If you disagree with the current approach, explain why and suggest alternatives.
 ```
 
-2. Run Gemini CLI. Always set `GEMINI_SANDBOX=false` (nested sandbox-exec is prohibited on macOS):
+2. Run Gemini CLI with three invariants:
+   - `GEMINI_SANDBOX=false` (nested sandbox-exec is prohibited on macOS).
+   - `--allowed-mcp-server-names ""` and `-e ""` to isolate from the caller's MCP servers and extensions; without this, persona voices (e.g. voicevox) or prior-session state can leak in, including off-topic responses that answer a different question than the one you sent.
+   - Redirect output to a tempfile so it survives regardless of retrieval path.
 
-**If `run_in_background` and `TaskOutput` are available**:
+**If Bash supports `run_in_background: true`** (typical case):
 ```bash
 # Bash tool: run_in_background: true, timeout: 120000
-GEMINI_SANDBOX=false gemini -p "$(cat <<'GEMINI_PROMPT'
+TMPFILE=$(mktemp /tmp/gemini-opinion.XXXXXX.log)
+GEMINI_SANDBOX=false gemini --allowed-mcp-server-names "" -e "" -p "$(cat <<'GEMINI_PROMPT'
 <constructed prompt>
 GEMINI_PROMPT
-)" -o text 2>&1
+)" -o text > "$TMPFILE" 2>&1
 ```
-Then retrieve with `TaskOutput` (`block: true`, `timeout: 120000`).
+Wait for completion, then retrieve output. Preferred: `BashOutput` with the returned `shell_id`. If `BashOutput` is not exposed in your environment, `Read` the `$TMPFILE` directly. `TaskOutput` is for Agent/Task tool tasks — do not use it here.
 
-**Otherwise** (tmpfile + poll):
+**If `run_in_background` is unavailable** (foreground-only environment, last resort):
 ```bash
 TMPFILE=$(mktemp /tmp/gemini-opinion.XXXXXX.log)
-GEMINI_SANDBOX=false gemini -p "$(cat <<'GEMINI_PROMPT'
+GEMINI_SANDBOX=false gemini --allowed-mcp-server-names "" -e "" -p "$(cat <<'GEMINI_PROMPT'
 <constructed prompt>
 GEMINI_PROMPT
 )" -o text > "$TMPFILE" 2>&1 &
@@ -46,7 +50,7 @@ PID=$!
 ```
 Poll `$PID` every 10-15s. Hard timeout: 300s. On timeout, `kill $PID` and clean up `$TMPFILE`.
 
-3. Parse output: ignore startup logs, MCP errors, and reasoning traces before the final text. Treat the last plain-text block as the answer.
+3. Parse output: ignore startup logs, MCP registration/tool-call errors (these may appear inline mid-output, not just before the answer), reasoning traces, and persona/voice styling leaked from the caller's MCP context (e.g. a voicevox persona bleeding into Gemini's reply). Treat the final substantive plain-text block as the answer. If it arrives in a persona voice, extract the content and present it in neutral prose.
 
 4. Present both perspectives (labeled by model), highlight agreements and disagreements. Evaluate Gemini's suggestion critically — do not blindly adopt it.
 

--- a/config/agents/skills/gemini-second-opinion/SKILL.md
+++ b/config/agents/skills/gemini-second-opinion/SKILL.md
@@ -28,33 +28,28 @@ Provide your independent analysis. If you disagree with the current approach, ex
    - `--allowed-mcp-server-names ""` and `-e ""` to isolate from the caller's MCP servers and extensions; without this, persona voices (e.g. voicevox) or prior-session state can leak in, including off-topic responses that answer a different question than the one you sent.
    - Redirect output to a tempfile so it survives regardless of retrieval path.
 
+**Pre-choose the output path yourself** (used by both code branches below). Pick a unique literal filesystem path in advance — e.g., `/tmp/gemini-opinion-<unix-timestamp>-<random>.log`, assembled in your working context (not via `mktemp` inside the snippet, because that binds the path to a shell variable you cannot retrieve later). Reuse the exact same literal path verbatim in the Bash invocation and in the follow-up `Read`. This avoids any dependency on a harness-specific output-capture tool (`BashOutput`, task output files, etc.).
+
 **If Bash supports `run_in_background: true`** (typical case):
 ```bash
-# Bash tool: run_in_background: true, timeout: 120000
-# Echo the tempfile path so it is retrievable via BashOutput;
-# Gemini output itself is redirected to the file.
-TMPFILE=$(mktemp /tmp/gemini-opinion.XXXXXX.log)
-echo "TMPFILE=$TMPFILE"
+# Bash tool: run_in_background: true, timeout: 300000
+# Substitute <TMPFILE> with the literal path you chose above.
 GEMINI_SANDBOX=false gemini --allowed-mcp-server-names "" -e "" -p "$(cat <<'GEMINI_PROMPT'
 <constructed prompt>
 GEMINI_PROMPT
-)" -o text > "$TMPFILE" 2>&1
-echo "EXIT=$?"
+)" -o text > <TMPFILE> 2>&1
 ```
-Retrieve in two steps: (a) `BashOutput` with the returned `shell_id` — use it to capture the echoed `TMPFILE=...` path and to confirm completion via the `EXIT=` line; it will NOT contain Gemini's output because stdout/stderr are redirected to the file. (b) `Read` the concrete `TMPFILE` path for the actual answer. After reading, delete the file with `rm "<tmpfile>"` (keep it only when debugging). `TaskOutput` is for Agent/Task tool tasks — do not use it here.
+Wait for the background task to finish, then `Read <TMPFILE>`. Do NOT add `sleep` / `kill -0` / `pgrep` poll loops — they burn tool-call budget and the harness's completion signal is authoritative. An interim `Read` "to peek at progress" is also unnecessary; the file is incomplete until Gemini exits. **If you are a nested subagent** (running inside an Agent/Task tool), do NOT use this background path — a subagent that ends its turn while Gemini is still running will lose the background task. Use the foreground fallback below instead. After reading, `rm <TMPFILE>`; if the harness denies `rm`, leave the file — `/tmp` is reclaimed by the OS. `TaskOutput` is for Agent/Task tool tasks — do not use it here.
 
-**If `run_in_background` is unavailable** (foreground-only environment, last resort):
+**Foreground fallback** (use when `run_in_background` is unavailable, OR when you are a nested subagent):
 ```bash
-TMPFILE=$(mktemp /tmp/gemini-opinion.XXXXXX.log)
-echo "TMPFILE=$TMPFILE"
+# Bash tool: timeout: 300000
 GEMINI_SANDBOX=false gemini --allowed-mcp-server-names "" -e "" -p "$(cat <<'GEMINI_PROMPT'
 <constructed prompt>
 GEMINI_PROMPT
-)" -o text > "$TMPFILE" 2>&1 &
-PID=$!
-echo "PID=$PID"
+)" -o text > <TMPFILE> 2>&1
 ```
-Capture the echoed `TMPFILE` and `PID` from the foreground output; subsequent tool calls need the concrete values. Poll with `kill -0 <PID>` every 10-15s. Hard timeout: 300s. On timeout, `kill <PID>` and `rm <TMPFILE>`. On success, `Read <TMPFILE>` then `rm <TMPFILE>`. Do NOT use `trap 'rm -f $TMPFILE' EXIT` in the launching shell — the trap fires when that Bash invocation exits, deleting the file before the background process writes to it.
+Bash blocks until Gemini finishes or the tool timeout fires. On return, `Read <TMPFILE>` and then `rm <TMPFILE>`. Do not use `&` + `$!` polling — it adds PID tracking for no benefit once you control the Bash tool timeout. Do NOT use `trap 'rm -f $TMPFILE' EXIT` in any snippet that backgrounds a process — the trap fires when the launching shell exits, deleting the file before the background process writes to it.
 
 3. Parse output: ignore startup logs, MCP registration/tool-call errors (these may appear inline mid-output, not just before the answer), reasoning traces, and persona/voice styling leaked from the caller's MCP context (e.g. a voicevox persona bleeding into Gemini's reply). Treat the final substantive plain-text block as the answer. If it arrives in a persona voice, extract the content and present it in neutral prose.
 


### PR DESCRIPTION
  ## Why
  The Codex and Gemini second-opinion skills had fragile output retrieval assumptions (`TaskOutput` was referenced incorrectly for Bash-backed runs) and Gemini invocations inherited the caller's MCP servers/extensions, causing persona voices (e.g. voicevox) and prior-session state to leak into replies —  sometimes even answering the wrong question. This PR makes output capture robust and isolates each invocation.

  ## What

  - Codex skill: always redirect to a tempfile, clarify retrieval order (`BashOutput` → `Read $TMPFILE`), and note `TaskOutput` is Agent/Task-only. Extend output-parsing rules to strip trailing metadata (`tokens used`, session id) and handle duplicated answers.
  - Gemini skill: add `--allowed-mcp-server-names ""` and `-e ""` to isolate from the caller's MCP servers/extensions, redirect output to a tempfile, and align retrieval guidance with the Codex skill. Expand parsing rules to cover inline MCP errors and persona-voice leakage (extract content, present in neutral prose).
  - Reframe the branching from “tools available?” to “does Bash support `run_in_background`?”, matching actual execution paths.
