### PR TITLE
Split agent CLIs into version-pinned bin packages

### DIFF
--- a/config/agents/skills/gemini-second-opinion/SKILL.md
+++ b/config/agents/skills/gemini-second-opinion/SKILL.md
@@ -32,25 +32,20 @@ Provide your independent analysis. If you disagree with the current approach, ex
 
 ### Isolated HOME preamble
 
-Inline this block before the `gemini` call. It inherits the user's real `security.auth` from `~/.gemini/settings.json` (so Vertex AI / API-key / OAuth all work), while disabling MCP, IDE, preview features, prompt completion, and hooks. `node` is guaranteed to be present because Gemini CLI itself is a Node app.
+Inline this block before the `gemini` call. It inherits the user's real `security.auth` from `~/.gemini/settings.json` (so Vertex AI / API-key / OAuth all work), while disabling MCP, IDE, preview features, prompt completion, and hooks. Requires `jq` on PATH.
 
 ```bash
 ISO=<ISOLATED_HOME>   # literal path you chose, e.g. /tmp/gemini-skill-home-1776644000-abc
 mkdir -p "$ISO/.gemini" "$ISO/.config/gcloud"
 cp "$HOME/.gemini/oauth_creds.json" "$ISO/.gemini/" 2>/dev/null || true
 cp "$HOME/.config/gcloud/application_default_credentials.json" "$ISO/.config/gcloud/" 2>/dev/null || true
-node -e '
-const fs=require("fs"), path=require("path");
-const p=path.join(process.env.HOME, ".gemini/settings.json");
-let c={}; try { c = JSON.parse(fs.readFileSync(p,"utf8")); } catch(_){}
-c.tools = { sandbox: false };
-c.ide = { enabled: false };
-c.mcpServers = {};
-delete c.hooks;
-delete c.includeDirectories;
-c.general = Object.assign({}, c.general||{}, { previewFeatures:false, enablePromptCompletion:false });
-c.privacy = { usageStatisticsEnabled: false };
-process.stdout.write(JSON.stringify(c));
+{ cat "$HOME/.gemini/settings.json" 2>/dev/null || echo '{}'; } | jq '
+  del(.hooks, .includeDirectories)
+  | .tools = { sandbox: false }
+  | .ide = { enabled: false }
+  | .mcpServers = {}
+  | .general = ((.general // {}) + { previewFeatures: false, enablePromptCompletion: false })
+  | .privacy = { usageStatisticsEnabled: false }
 ' > "$ISO/.gemini/settings.json"
 ```
 
@@ -95,6 +90,7 @@ Specific failure modes:
 - `ADC must be external_account, authorized_user, or external_account_authorized_user` — the ADC file was not copied into the isolated `HOME`. Verify `~/.config/gcloud/application_default_credentials.json` exists on the real `HOME`.
 - `Invalid policy rule: mcpName is required if specified (cannot be empty)` — you passed `--allowed-mcp-server-names ""` or `-e ""`. Remove those flags; this skill uses isolated `HOME` for isolation, not flags.
 - Timeout with 0 bytes output — the isolated `HOME` was not applied, or its `settings.json` still has `ide.enabled: true` / non-empty `mcpServers`. Double-check the preamble was inlined verbatim.
+- `jq: command not found` or empty `settings.json` — ensure `jq` is installed and on PATH in the harness you are running under, or replace the `jq` pipeline with an equivalent `python3 -c` / inline heredoc snippet.
 
 ## Shell Escaping
 

--- a/config/agents/skills/gemini-second-opinion/SKILL.md
+++ b/config/agents/skills/gemini-second-opinion/SKILL.md
@@ -25,39 +25,76 @@ Provide your independent analysis. If you disagree with the current approach, ex
 
 2. Run Gemini CLI with three invariants:
    - `GEMINI_SANDBOX=false` (nested sandbox-exec is prohibited on macOS).
-   - `--allowed-mcp-server-names ""` and `-e ""` to isolate from the caller's MCP servers and extensions; without this, persona voices (e.g. voicevox) or prior-session state can leak in, including off-topic responses that answer a different question than the one you sent.
+   - **Isolated `HOME`** to prevent MCP servers, IDE companion integration, and persona/voice extensions from deadlocking Gemini in the non-TTY Bash subshell. Gemini CLI 0.38.2+ spawns MCP children and opens an IDE-companion socket on startup that hang indefinitely in Claude Code's Bash sandbox (no PTY; `openpty` is prohibited). The older `--allowed-mcp-server-names ""` / `-e ""` approach is now rejected by 0.38.2 as an invalid policy rule (`mcpName is required if specified (cannot be empty)`). An isolated `HOME` with a minimal `settings.json` is the only reliable way to run Gemini headlessly from Claude Code Bash; it also prevents persona voices and prior-session state from leaking into the response.
    - Redirect output to a tempfile so it survives regardless of retrieval path.
 
-**Pre-choose the output path yourself** (used by both code branches below). Pick a unique literal filesystem path in advance — e.g., `/tmp/gemini-opinion-<unix-timestamp>-<random>.log`, assembled in your working context (not via `mktemp` inside the snippet, because that binds the path to a shell variable you cannot retrieve later). Reuse the exact same literal path verbatim in the Bash invocation and in the follow-up `Read`. This avoids any dependency on a harness-specific output-capture tool (`BashOutput`, task output files, etc.).
+**Pre-choose the output path yourself** (used by both code branches below). Pick a unique literal filesystem path in advance — e.g., `/tmp/gemini-opinion-<unix-timestamp>-<random>.log`, assembled in your working context (not via `mktemp` inside the snippet, because that binds the path to a shell variable you cannot retrieve later). Reuse the exact same literal path verbatim in the Bash invocation and in the follow-up `Read`. This avoids any dependency on a harness-specific output-capture tool (`BashOutput`, task output files, etc.). Pick a similarly unique literal path for the isolated `HOME` directory — e.g., `/tmp/gemini-skill-home-<unix-timestamp>-<random>`.
+
+### Isolated HOME preamble
+
+Inline this block before the `gemini` call. It inherits the user's real `security.auth` from `~/.gemini/settings.json` (so Vertex AI / API-key / OAuth all work), while disabling MCP, IDE, preview features, prompt completion, and hooks. `node` is guaranteed to be present because Gemini CLI itself is a Node app.
+
+```bash
+ISO=<ISOLATED_HOME>   # literal path you chose, e.g. /tmp/gemini-skill-home-1776644000-abc
+mkdir -p "$ISO/.gemini" "$ISO/.config/gcloud"
+cp "$HOME/.gemini/oauth_creds.json" "$ISO/.gemini/" 2>/dev/null || true
+cp "$HOME/.config/gcloud/application_default_credentials.json" "$ISO/.config/gcloud/" 2>/dev/null || true
+node -e '
+const fs=require("fs"), path=require("path");
+const p=path.join(process.env.HOME, ".gemini/settings.json");
+let c={}; try { c = JSON.parse(fs.readFileSync(p,"utf8")); } catch(_){}
+c.tools = { sandbox: false };
+c.ide = { enabled: false };
+c.mcpServers = {};
+delete c.hooks;
+delete c.includeDirectories;
+c.general = Object.assign({}, c.general||{}, { previewFeatures:false, enablePromptCompletion:false });
+c.privacy = { usageStatisticsEnabled: false };
+process.stdout.write(JSON.stringify(c));
+' > "$ISO/.gemini/settings.json"
+```
 
 **If Bash supports `run_in_background: true`** (typical case):
 ```bash
 # Bash tool: run_in_background: true, timeout: 300000
-# Substitute <TMPFILE> with the literal path you chose above.
-GEMINI_SANDBOX=false gemini --allowed-mcp-server-names "" -e "" -p "$(cat <<'GEMINI_PROMPT'
+# Substitute <TMPFILE> and <ISOLATED_HOME> with the literal paths you chose above.
+ISO=<ISOLATED_HOME>
+# ... (inline the Isolated HOME preamble here) ...
+HOME="$ISO" GEMINI_SANDBOX=false gemini -p "$(cat <<'GEMINI_PROMPT'
 <constructed prompt>
 GEMINI_PROMPT
-)" -o text > <TMPFILE> 2>&1
+)" -o text < /dev/null > <TMPFILE> 2>&1
+rm -rf "$ISO"
 ```
 Wait for the background task to finish, then `Read <TMPFILE>`. Do NOT add `sleep` / `kill -0` / `pgrep` poll loops — they burn tool-call budget and the harness's completion signal is authoritative. An interim `Read` "to peek at progress" is also unnecessary; the file is incomplete until Gemini exits. **If you are a nested subagent** (running inside an Agent/Task tool), do NOT use this background path — a subagent that ends its turn while Gemini is still running will lose the background task. Use the foreground fallback below instead. After reading, `rm <TMPFILE>`; if the harness denies `rm`, leave the file — `/tmp` is reclaimed by the OS. `TaskOutput` is for Agent/Task tool tasks — do not use it here.
 
 **Foreground fallback** (use when `run_in_background` is unavailable, OR when you are a nested subagent):
 ```bash
 # Bash tool: timeout: 300000
-GEMINI_SANDBOX=false gemini --allowed-mcp-server-names "" -e "" -p "$(cat <<'GEMINI_PROMPT'
+ISO=<ISOLATED_HOME>
+# ... (inline the Isolated HOME preamble here) ...
+HOME="$ISO" GEMINI_SANDBOX=false gemini -p "$(cat <<'GEMINI_PROMPT'
 <constructed prompt>
 GEMINI_PROMPT
-)" -o text > <TMPFILE> 2>&1
+)" -o text < /dev/null > <TMPFILE> 2>&1
+rm -rf "$ISO"
 ```
 Bash blocks until Gemini finishes or the tool timeout fires. On return, `Read <TMPFILE>` and then `rm <TMPFILE>`. Do not use `&` + `$!` polling — it adds PID tracking for no benefit once you control the Bash tool timeout. Do NOT use `trap 'rm -f $TMPFILE' EXIT` in any snippet that backgrounds a process — the trap fires when the launching shell exits, deleting the file before the background process writes to it.
 
-3. Parse output: ignore startup logs, MCP registration/tool-call errors (these may appear inline mid-output, not just before the answer), reasoning traces, and persona/voice styling leaked from the caller's MCP context (e.g. a voicevox persona bleeding into Gemini's reply). Treat the final substantive plain-text block as the answer. If it arrives in a persona voice, extract the content and present it in neutral prose.
+Always close stdin with `< /dev/null`. Without it, Gemini may block waiting for additional prompt input appended via stdin.
+
+3. Parse output: ignore startup logs, MCP registration/tool-call errors (these may still appear inline in the relaunched-heap phase), reasoning traces, and persona/voice styling that somehow still leaked in. Treat the final substantive plain-text block as the answer. If it arrives in a persona voice, extract the content and present it in neutral prose.
 
 4. Present both perspectives (labeled by model), highlight agreements and disagreements. Evaluate Gemini's suggestion critically — do not blindly adopt it.
 
 ## Error Handling
 
-On any failure — `gemini` not found, auth error (`ADC must be`, `gcloud.auth`), network error, or timeout — report the reason to the user and proceed with your own analysis only. Discard partial output on timeout as unreliable.
+On any failure — `gemini` not found, auth error (`ADC must be`, `gcloud.auth`), network error, or timeout — report the reason to the user and proceed with your own analysis only. Discard partial output on timeout as unreliable. Always `rm -rf "$ISO"` on error paths too.
+
+Specific failure modes:
+- `ADC must be external_account, authorized_user, or external_account_authorized_user` — the ADC file was not copied into the isolated `HOME`. Verify `~/.config/gcloud/application_default_credentials.json` exists on the real `HOME`.
+- `Invalid policy rule: mcpName is required if specified (cannot be empty)` — you passed `--allowed-mcp-server-names ""` or `-e ""`. Remove those flags; this skill uses isolated `HOME` for isolation, not flags.
+- Timeout with 0 bytes output — the isolated `HOME` was not applied, or its `settings.json` still has `ide.enabled: true` / non-empty `mcpServers`. Double-check the preamble was inlined verbatim.
 
 ## Shell Escaping
 

--- a/config/agents/skills/gemini-second-opinion/SKILL.md
+++ b/config/agents/skills/gemini-second-opinion/SKILL.md
@@ -36,7 +36,9 @@ Inline this block before the `gemini` call. It inherits the user's real `securit
 
 ```bash
 ISO=<ISOLATED_HOME>   # literal path you chose, e.g. /tmp/gemini-skill-home-1776644000-abc
+umask 077
 mkdir -p "$ISO/.gemini" "$ISO/.config/gcloud"
+chmod 700 "$ISO" "$ISO/.gemini" "$ISO/.config" "$ISO/.config/gcloud"
 cp "$HOME/.gemini/oauth_creds.json" "$ISO/.gemini/" 2>/dev/null || true
 cp "$HOME/.config/gcloud/application_default_credentials.json" "$ISO/.config/gcloud/" 2>/dev/null || true
 { cat "$HOME/.gemini/settings.json" 2>/dev/null || echo '{}'; } | jq '
@@ -54,12 +56,12 @@ cp "$HOME/.config/gcloud/application_default_credentials.json" "$ISO/.config/gcl
 # Bash tool: run_in_background: true, timeout: 300000
 # Substitute <TMPFILE> and <ISOLATED_HOME> with the literal paths you chose above.
 ISO=<ISOLATED_HOME>
+trap 'rm -rf "$ISO"' EXIT
 # ... (inline the Isolated HOME preamble here) ...
 HOME="$ISO" GEMINI_SANDBOX=false gemini -p "$(cat <<'GEMINI_PROMPT'
 <constructed prompt>
 GEMINI_PROMPT
 )" -o text < /dev/null > <TMPFILE> 2>&1
-rm -rf "$ISO"
 ```
 Wait for the background task to finish, then `Read <TMPFILE>`. Do NOT add `sleep` / `kill -0` / `pgrep` poll loops — they burn tool-call budget and the harness's completion signal is authoritative. An interim `Read` "to peek at progress" is also unnecessary; the file is incomplete until Gemini exits. **If you are a nested subagent** (running inside an Agent/Task tool), do NOT use this background path — a subagent that ends its turn while Gemini is still running will lose the background task. Use the foreground fallback below instead. After reading, `rm <TMPFILE>`; if the harness denies `rm`, leave the file — `/tmp` is reclaimed by the OS. `TaskOutput` is for Agent/Task tool tasks — do not use it here.
 
@@ -67,14 +69,14 @@ Wait for the background task to finish, then `Read <TMPFILE>`. Do NOT add `sleep
 ```bash
 # Bash tool: timeout: 300000
 ISO=<ISOLATED_HOME>
+trap 'rm -rf "$ISO"' EXIT
 # ... (inline the Isolated HOME preamble here) ...
 HOME="$ISO" GEMINI_SANDBOX=false gemini -p "$(cat <<'GEMINI_PROMPT'
 <constructed prompt>
 GEMINI_PROMPT
 )" -o text < /dev/null > <TMPFILE> 2>&1
-rm -rf "$ISO"
 ```
-Bash blocks until Gemini finishes or the tool timeout fires. On return, `Read <TMPFILE>` and then `rm <TMPFILE>`. Do not use `&` + `$!` polling — it adds PID tracking for no benefit once you control the Bash tool timeout. Do NOT use `trap 'rm -f $TMPFILE' EXIT` in any snippet that backgrounds a process — the trap fires when the launching shell exits, deleting the file before the background process writes to it.
+Bash blocks until Gemini finishes or the tool timeout fires. On return, `Read <TMPFILE>` and then `rm <TMPFILE>`. Do not use `&` + `$!` polling — it adds PID tracking for no benefit once you control the Bash tool timeout. The `trap 'rm -rf "$ISO"' EXIT` above is safe here because `gemini` runs in the foreground of the snippet's shell, so the trap fires only after `gemini` has exited. Do NOT add a trap that targets `<TMPFILE>` if you ever switch to shell-level `&` backgrounding of `gemini` — in that case the trap would fire when the launching shell exits, deleting the file before the background process writes to it.
 
 Always close stdin with `< /dev/null`. Without it, Gemini may block waiting for additional prompt input appended via stdin.
 
@@ -84,7 +86,7 @@ Always close stdin with `< /dev/null`. Without it, Gemini may block waiting for 
 
 ## Error Handling
 
-On any failure — `gemini` not found, auth error (`ADC must be`, `gcloud.auth`), network error, or timeout — report the reason to the user and proceed with your own analysis only. Discard partial output on timeout as unreliable. Always `rm -rf "$ISO"` on error paths too.
+On any failure — `gemini` not found, auth error (`ADC must be`, `gcloud.auth`), network error, or timeout — report the reason to the user and proceed with your own analysis only. Discard partial output on timeout as unreliable. The `trap 'rm -rf "$ISO"' EXIT` in the snippets above handles cleanup on both success and error paths; verify it is present if you inline the snippet manually.
 
 Specific failure modes:
 - `ADC must be external_account, authorized_user, or external_account_authorized_user` — the ADC file was not copied into the isolated `HOME`. Verify `~/.config/gcloud/application_default_credentials.json` exists on the real `HOME`.

--- a/config/gemini/policies/serena.toml
+++ b/config/gemini/policies/serena.toml
@@ -1,4 +1,5 @@
 [[rule]]
+toolName = "*"
 mcpName = "serena"
 decision = "allow"
 priority = 200

--- a/config/gemini/policies/voicevox.toml
+++ b/config/gemini/policies/voicevox.toml
@@ -1,4 +1,5 @@
 [[rule]]
+toolName = "*"
 mcpName = "voicevox"
 decision = "allow"
 priority = 200

--- a/packages/claude-code-bin/default.nix
+++ b/packages/claude-code-bin/default.nix
@@ -1,0 +1,29 @@
+# Claude Code native binary fetched from Google Cloud Storage, managed independently of nixpkgs.
+# Requires --impure flag for builtins.fetchurl (no hash verification).
+#
+# Update workflow: update `version` below, then deploy.
+{
+  lib,
+  stdenvNoCC,
+}:
+let
+  version = "2.1.112";
+  baseUrl = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
+  platformKey = "darwin-arm64";
+in
+stdenvNoCC.mkDerivation {
+  pname = "claude-code-bin";
+  inherit version;
+  src = builtins.fetchurl "${baseUrl}/${version}/${platformKey}/claude";
+  dontUnpack = true;
+  dontBuild = true;
+  dontStrip = true;
+  installPhase = "install -Dm755 $src $out/bin/claude";
+  meta = {
+    description = "Pre-built Claude Code native binary (darwin-arm64), version-pinned";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "claude";
+    platforms = [ "aarch64-darwin" ];
+  };
+}

--- a/packages/claude-code-sandboxed/default.nix
+++ b/packages/claude-code-sandboxed/default.nix
@@ -1,35 +1,14 @@
-# Sandboxed Claude Code CLI with pre-built binary.
-# Binary is fetched from Google Cloud Storage, managed independently from nixpkgs.
-# Requires --impure flag for builtins.fetchurl (no hash verification).
+# Sandboxed Claude Code CLI wrapping the version-pinned claude-code-bin.
 #
-# Update workflow: update `version` below, then deploy.
+# Binary version lives in packages/claude-code-bin/default.nix.
 {
   lib,
-  stdenvNoCC,
+  claude-code-bin,
   writeShellScriptBin,
   procps,
   ripgrep,
 }:
 let
-  version = "2.1.112";
-  baseUrl = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
-  platformKey = "darwin-arm64";
-
-  claudeBin = stdenvNoCC.mkDerivation {
-    pname = "claude-code-bin";
-    inherit version;
-    src = builtins.fetchurl "${baseUrl}/${version}/${platformKey}/claude";
-    dontUnpack = true;
-    dontBuild = true;
-    dontStrip = true;
-    installPhase = "install -Dm755 $src $out/bin/claude";
-    meta = {
-      license = lib.licenses.unfree;
-      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-      platforms = [ "aarch64-darwin" ];
-    };
-  };
-
   sandboxProfilePath = "\${HOME}/.claude/permissive-open.sb";
 in
 writeShellScriptBin "claude" ''
@@ -44,7 +23,7 @@ writeShellScriptBin "claude" ''
     ]
   }:$PATH"
 
-  CLAUDE_BIN="${claudeBin}/bin/claude"
+  CLAUDE_BIN="${claude-code-bin}/bin/claude"
 
   # --no-sandbox: bypass sandbox and execute the binary directly.
   # Useful when invoked from an already-sandboxed context (e.g., Gemini CLI).

--- a/packages/claude-code-sandboxed/default.nix
+++ b/packages/claude-code-sandboxed/default.nix
@@ -7,6 +7,7 @@
   writeShellScriptBin,
   procps,
   ripgrep,
+  jq,
 }:
 let
   sandboxProfilePath = "\${HOME}/.claude/permissive-open.sb";
@@ -20,6 +21,7 @@ writeShellScriptBin "claude" ''
     lib.makeBinPath [
       procps
       ripgrep
+      jq
     ]
   }:$PATH"
 

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -1,8 +1,14 @@
 { pkgs }:
 
-{
+rec {
   blackhole-2ch = pkgs.callPackage ./blackhole-2ch { };
-  claude-code-sandboxed = pkgs.callPackage ./claude-code-sandboxed { };
+  claude-code-bin = pkgs.callPackage ./claude-code-bin { };
+  claude-code-sandboxed = pkgs.callPackage ./claude-code-sandboxed {
+    inherit claude-code-bin;
+  };
   docker-compose = pkgs.callPackage ./docker-compose { };
-  gemini-cli-workforce = pkgs.callPackage ./gemini-cli-workforce { };
+  gemini-cli-bin = pkgs.callPackage ./gemini-cli-bin { };
+  gemini-cli-workforce = pkgs.callPackage ./gemini-cli-workforce {
+    inherit gemini-cli-bin;
+  };
 }

--- a/packages/gemini-cli-bin/default.nix
+++ b/packages/gemini-cli-bin/default.nix
@@ -28,6 +28,6 @@ stdenvNoCC.mkDerivation {
     description = "Pre-bundled Gemini CLI (npm @google/gemini-cli), version-pinned";
     license = lib.licenses.asl20;
     mainProgram = "gemini";
-    platforms = lib.platforms.darwin;
+    platforms = lib.platforms.unix;
   };
 }

--- a/packages/gemini-cli-bin/default.nix
+++ b/packages/gemini-cli-bin/default.nix
@@ -1,0 +1,33 @@
+# Pre-bundled Gemini CLI fetched from npm, managed independently of nixpkgs.
+# Requires --impure flag for builtins.fetchurl (no hash verification).
+#
+# Update workflow: update `version` below, then deploy.
+{
+  lib,
+  stdenvNoCC,
+  nodejs_22,
+}:
+let
+  version = "0.38.2";
+in
+stdenvNoCC.mkDerivation {
+  pname = "gemini-cli-bin";
+  inherit version;
+  src = builtins.fetchurl "https://registry.npmjs.org/@google/gemini-cli/-/gemini-cli-${version}.tgz";
+  dontBuild = true;
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/gemini-cli $out/bin
+    cp -r ./bundle/. $out/share/gemini-cli/
+    printf '#!%s\nexec %s/bin/node --no-warnings=DEP0040 %s/share/gemini-cli/gemini.js "$@"\n' \
+      "${stdenvNoCC.shell}" "${nodejs_22}" "$out" > $out/bin/gemini
+    chmod +x $out/bin/gemini
+    runHook postInstall
+  '';
+  meta = {
+    description = "Pre-bundled Gemini CLI (npm @google/gemini-cli), version-pinned";
+    license = lib.licenses.asl20;
+    mainProgram = "gemini";
+    platforms = lib.platforms.darwin;
+  };
+}

--- a/packages/gemini-cli-workforce/default.nix
+++ b/packages/gemini-cli-workforce/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  gemini-cli,
+  gemini-cli-bin,
   google-cloud-sdk,
   writeShellScriptBin,
 }:
@@ -9,7 +9,7 @@
 let
   globalLocation = "global";
   geminiWrapper = writeShellScriptBin "gemini" ''
-    GEMINI_BIN="${gemini-cli}/bin/gemini"
+    GEMINI_BIN="${gemini-cli-bin}/bin/gemini"
     GCLOUD_BIN_DIR="${google-cloud-sdk}/bin"
     GCLOUD_BIN="$GCLOUD_BIN_DIR/gcloud"
     export PATH="$GCLOUD_BIN_DIR:$PATH"
@@ -83,7 +83,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "gemini-cli-workforce";
-  inherit (gemini-cli) version;
+  inherit (gemini-cli-bin) version;
 
   dontUnpack = true;
   dontBuild = true;

--- a/packages/gemini-cli-workforce/default.nix
+++ b/packages/gemini-cli-workforce/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   gemini-cli-bin,
   google-cloud-sdk,
+  ripgrep,
   writeShellScriptBin,
 }:
 
@@ -12,7 +13,7 @@ let
     GEMINI_BIN="${gemini-cli-bin}/bin/gemini"
     GCLOUD_BIN_DIR="${google-cloud-sdk}/bin"
     GCLOUD_BIN="$GCLOUD_BIN_DIR/gcloud"
-    export PATH="$GCLOUD_BIN_DIR:$PATH"
+    export PATH="$GCLOUD_BIN_DIR:${ripgrep}/bin:$PATH"
     export GOOGLE_CLOUD_LOCATION="${globalLocation}"
     export GOOGLE_GENAI_USE_VERTEXAI="true"
     unset GOOGLE_API_KEY GEMINI_API_KEY


### PR DESCRIPTION


## Why
Gemini CLI was installed directly from nixpkgs, so version bumps had to wait on a nixpkgs-level update; Claude Code had its own GCS-direct fetch, but the fetch logic lived inside the sandbox wrapper, coupling artifact retrieval with runtime behavior. Gemini CLI 0.38.2 also tightened the policy schema (`toolName` is now required, empty `mcpName` rejected) and added a startup path that opens MCP children and an IDE-companion socket, deadlocking the gemini-second-opinion skill in Claude Code's non-TTY Bash sandbox.

## What
- Establish a symmetric `*-bin` / wrapper split for both agents. `*-bin` owns the pinned upstream artifact; the existing wrapper keeps its runtime concerns (sandbox-exec for Claude, WIF + Vertex for Gemini). A single-line `version = "..."` edit in the `-bin` file is the whole update workflow for either CLI.
- For Gemini, fetch the pre-bundled `@google/gemini-cli` npm tarball rather than rebuilding from source via `buildNpmPackage`. Rebuilding duplicates work nixpkgs already does and lengthens local rebuilds; the npm tarball ships a ready-to-run `bundle/gemini.js` that mirrors Claude Code's pre-built native binary on GCS. Auto-updater is left enabled and fails harmlessly against the read-only Nix store (no patch maintenance burden).
- Wire the custom-to-custom dependency (`claude-code-sandboxed` → `claude-code-bin`, `gemini-cli-workforce` → `gemini-cli-bin`) via `rec { ... }` in `packages/default.nix` with explicit `inherit`. Rejected: adding a global overlay — it would expand public surface for purely internal plumbing.
- Fix policies broken by the new schema by adding `toolName = "*"` to MCP-scope allow rules instead of dropping `mcpName`, preserving the "all tools of a specific MCP server" semantics.
- Rework the gemini-second-opinion skill to isolate via a disposable `HOME` with a synthesized minimal `settings.json` (MCP / IDE / hooks / preview features off) plus copied credentials. Flag-based isolation (`--allowed-mcp-server-names ""`, `-e ""`) is no longer accepted by 0.38.2, and running under the real `HOME` deadlocks on MCP/IDE startup.

## References
N/A
