### PR TITLE
Update Codex CLI packaging and memory settings

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -1,7 +1,7 @@
 # See: https://developers.openai.com/codex/config-reference
 
 # Model
-model = "gpt-5.4-mini"
+model = "gpt-5.4"
 model_reasoning_effort = "medium"
 model_reasoning_summary = "auto"
 model_verbosity = "medium"
@@ -13,6 +13,10 @@ web_search = "live"
 notify = ["bash", "-lc", "afplay /System/Library/Sounds/Ping.aiff"]
 personality = "pragmatic"
 project_doc_fallback_filenames = ["CLAUDE.md", "GEMINI.md"]
+
+# Features
+[features]
+memories = true
 
 # Session history
 [history]

--- a/modules/shared/agents.nix
+++ b/modules/shared/agents.nix
@@ -10,7 +10,6 @@
   home.packages =
     with pkgs;
     [
-      codex
       terminal-notifier
     ]
     ++ [
@@ -19,6 +18,7 @@
     ]
     ++ [
       customPackages.claude-code-sandboxed
+      customPackages.codex-bin
       customPackages.gemini-cli-workforce
     ];
 

--- a/packages/codex-bin/default.nix
+++ b/packages/codex-bin/default.nix
@@ -1,19 +1,22 @@
 # Codex CLI native binary fetched from GitHub Releases, managed independently of nixpkgs.
-# Requires --impure flag for builtins.fetchurl (no hash verification).
-#
-# Update workflow: update `version` below, then deploy.
+# Update workflow: update `version` and `hash` below, then deploy.
 {
+  fetchurl,
   lib,
   stdenvNoCC,
 }:
 let
   version = "0.122.0";
   asset = "codex-aarch64-apple-darwin";
-  src = builtins.fetchurl "https://github.com/openai/codex/releases/download/rust-v${version}/${asset}.tar.gz";
+  src = fetchurl {
+    url = "https://github.com/openai/codex/releases/download/rust-v${version}/${asset}.tar.gz";
+    hash = "sha256-dOaIXhpY148CSfrtEm62qyIPnONOdiP55BCCVQNdYcw=";
+  };
 in
 stdenvNoCC.mkDerivation {
   pname = "codex-bin";
   inherit version src;
+  # The upstream tarball expands to a single binary at archive root.
   sourceRoot = ".";
   dontBuild = true;
   dontStrip = true;

--- a/packages/codex-bin/default.nix
+++ b/packages/codex-bin/default.nix
@@ -1,0 +1,28 @@
+# Codex CLI native binary fetched from GitHub Releases, managed independently of nixpkgs.
+# Requires --impure flag for builtins.fetchurl (no hash verification).
+#
+# Update workflow: update `version` below, then deploy.
+{
+  lib,
+  stdenvNoCC,
+}:
+let
+  version = "0.122.0";
+  asset = "codex-aarch64-apple-darwin";
+  src = builtins.fetchurl "https://github.com/openai/codex/releases/download/rust-v${version}/${asset}.tar.gz";
+in
+stdenvNoCC.mkDerivation {
+  pname = "codex-bin";
+  inherit version src;
+  sourceRoot = ".";
+  dontBuild = true;
+  dontStrip = true;
+  installPhase = "install -Dm755 ${asset} $out/bin/codex";
+  meta = {
+    description = "Pre-built Codex CLI native binary (darwin-arm64), version-pinned";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "codex";
+    platforms = [ "aarch64-darwin" ];
+  };
+}

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -6,6 +6,7 @@ rec {
   claude-code-sandboxed = pkgs.callPackage ./claude-code-sandboxed {
     inherit claude-code-bin;
   };
+  codex-bin = pkgs.callPackage ./codex-bin { };
   docker-compose = pkgs.callPackage ./docker-compose { };
   gemini-cli-bin = pkgs.callPackage ./gemini-cli-bin { };
   gemini-cli-workforce = pkgs.callPackage ./gemini-cli-workforce {


### PR DESCRIPTION


## Why
The shared agent setup depended on the nixpkgs Codex package, which can lag the upstream Codex release channel and makes it harder to pin the exact CLI build used on this Darwin host. Codex configuration also needed to opt in to the current full GPT-5.4 model and persistent memory support so future sessions carry stable local context forward.

## What
This chooses a small custom binary package for Codex instead of continuing to inherit the nixpkgs package, because the upstream release artifact can be pinned directly and updated independently of the nixpkgs revision. The package is intentionally Darwin arm64-specific, matching this machine's target platform, rather than introducing a broader cross-platform abstraction before there is another consumer. The Codex runtime configuration is updated at the same time because the packaging change is meant to move this environment onto the current native Codex workflow, not just swap install sources.
