### PR TITLE
Update voicevox-cli to release idle Core memory

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1776141552,
-        "narHash": "sha256-eLljj6S9SH5unr1IlE+FKipqnWgZ/zlyC+M4mnjvzjc=",
+        "lastModified": 1776782920,
+        "narHash": "sha256-ioSxbfX2yb+l/bvUp0tswjLXO4cNUjzpBZcPoGGlr1A=",
         "owner": "usabarashi",
         "repo": "voicevox-cli",
-        "rev": "388137ee59f81d037c82034f543f5f442054b0c6",
+        "rev": "00832e845442760349e5b2f0bf20252f7e76e8b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION


## Why
The pinned `voicevox-cli` revision carried a daemon defect where longer synthesis responses could exceed the server-side IPC frame limit and close the connection, surfacing to clients as "No response from daemon". On macOS it also retained Core memory while idle, so long-lived sessions grew resident memory without release.

## What
Bumped the `voicevox-cli` flake input to the upstream revision that ships both fixes rather than waiting for the next batched `nix flake update`. A targeted, single-input bump was preferred because the motivating fix is user-visible and specific to this input; bundling it with unrelated input updates would make bisecting any regression harder. No nix-side configuration change is needed since the daemon frame limits and allocator hook are handled upstream.

## References
- usabarashi/voicevox-cli#134
