### PR TITLE
Introduce local LLM stack with Ollama and OpenCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ nix-collect-garbage -d && nix-store --gc
 > On macOS, if GC fails with "Operation not permitted", run from the Terminal app
 > with Full Disk Access enabled (System Settings > Privacy & Security > Full Disk Access).
 
+## Local LLM (private only)
+
+The `private` host runs Ollama as a user LaunchAgent for OpenCode backend experimentation.
+After first deploy, bootstrap the model once:
+
+```bash
+ollama pull qwen3.6:35b-a3b-q4_K_M
+ollama create qwen3.6-full -f config/ollama/modelfiles/qwen3.6-full.Modelfile
+```
+
+The derivative (`qwen3.6-full`) forces all 41 layers to GPU via
+`PARAMETER num_gpu 41`, keeping the M2 Pro 25 GiB Metal budget full-GPU and
+avoiding CPU offload on the output layer. OpenCode's model reference in
+`config/opencode/opencode.json` points at this derivative tag.
+
 ## Extra Packages (optional)
 
 Git-untracked, machine-specific configuration can be added via `~/.config/nix-extra/`.

--- a/config/ollama/modelfiles/qwen3.6-full.Modelfile
+++ b/config/ollama/modelfiles/qwen3.6-full.Modelfile
@@ -1,0 +1,2 @@
+FROM qwen3.6:35b-a3b-q4_K_M
+PARAMETER num_gpu 41

--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "autoupdate": false,
+  "autoshare": false,
+  "permission": {
+    "bash": "ask",
+    "edit": "ask",
+    "read": "allow",
+    "webfetch": "ask"
+  },
+  "mcp": {
+    "voicevox": {
+      "type": "local",
+      "command": ["voicevox-mcp-server"],
+      "timeout": 120000
+    },
+    "serena": {
+      "type": "local",
+      "command": [
+        "serena",
+        "start-mcp-server",
+        "--context",
+        "oaicompat-agent",
+        "--project-from-cwd",
+        "--enable-web-dashboard",
+        "False",
+        "--enable-gui-log-window",
+        "False"
+      ],
+      "environment": {
+        "SERENA_HOME": ".serena"
+      }
+    }
+  },
+  "provider": {
+    "ollama-local": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Ollama (local)",
+      "options": {
+        "baseURL": "http://127.0.0.1:11434/v1"
+      },
+      "models": {
+        "qwen3.6-full": {
+          "name": "Qwen3.6 35B MoE Q4 full-GPU (local)",
+          "tool_call": true,
+          "reasoning": true,
+          "limit": {
+            "context": 32768,
+            "output": 8192
+          }
+        }
+      }
+    }
+  },
+  "model": "ollama-local/qwen3.6-full"
+}

--- a/home/private/default.nix
+++ b/home/private/default.nix
@@ -55,6 +55,9 @@
   };
 
   # Weekly truncate of Ollama logs (launchd has no built-in rotation).
+  # `: > $f` on its own leaves the file sparse because `ollama serve` keeps
+  # the write fd open and retains its offset. Kickstart the agent first so
+  # the process closes its log fds, then truncate.
   launchd.agents.ollama-log-rotate = {
     enable = true;
     config = {
@@ -62,11 +65,18 @@
         "/bin/sh"
         "-c"
         ''
+          rotate=0
           for f in "${homeDirectory}/Library/Logs/ollama/"*.log; do
             [ -f "$f" ] || continue
             size=$(/usr/bin/stat -f%z "$f" 2>/dev/null || echo 0)
-            [ "$size" -gt 52428800 ] && : > "$f"
+            [ "$size" -gt 52428800 ] && rotate=1
           done
+          if [ "$rotate" -eq 1 ]; then
+            /bin/launchctl kickstart -k "gui/$(/usr/bin/id -u)/org.nix-community.home.ollama" 2>/dev/null || true
+            for f in "${homeDirectory}/Library/Logs/ollama/"*.log; do
+              [ -f "$f" ] && : > "$f"
+            done
+          fi
         ''
       ];
       StartCalendarInterval = [

--- a/home/private/default.nix
+++ b/home/private/default.nix
@@ -1,5 +1,6 @@
 {
   pkgs,
+  config,
   userName,
   homeDirectory,
   ...
@@ -11,6 +12,10 @@
     username = userName;
     inherit homeDirectory;
     stateVersion = "25.11";
+
+    activation.createOllamaLogDir = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+      run mkdir -p "${homeDirectory}/Library/Logs/ollama"
+    '';
   };
 
   targets.darwin.copyApps = {
@@ -21,10 +26,60 @@
   home.packages = with pkgs; [
     discord
     iina
+    ollama
     ripgrep
     slack
     zoom-us
   ];
+
+  launchd.agents.ollama = {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.ollama}/bin/ollama"
+        "serve"
+      ];
+      RunAtLoad = true;
+      KeepAlive = true;
+      ThrottleInterval = 30;
+      StandardOutPath = "${homeDirectory}/Library/Logs/ollama/stdout.log";
+      StandardErrorPath = "${homeDirectory}/Library/Logs/ollama/stderr.log";
+      EnvironmentVariables = {
+        OLLAMA_HOST = "127.0.0.1:11434";
+        OLLAMA_KEEP_ALIVE = "5m";
+        OLLAMA_MAX_LOADED_MODELS = "1";
+        OLLAMA_FLASH_ATTENTION = "1";
+        OLLAMA_KV_CACHE_TYPE = "q8_0";
+      };
+    };
+  };
+
+  # Weekly truncate of Ollama logs (launchd has no built-in rotation).
+  launchd.agents.ollama-log-rotate = {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "/bin/sh"
+        "-c"
+        ''
+          for f in "${homeDirectory}/Library/Logs/ollama/"*.log; do
+            [ -f "$f" ] || continue
+            size=$(/usr/bin/stat -f%z "$f" 2>/dev/null || echo 0)
+            [ "$size" -gt 52428800 ] && : > "$f"
+          done
+        ''
+      ];
+      StartCalendarInterval = [
+        {
+          Weekday = 0;
+          Hour = 2;
+          Minute = 0;
+        }
+      ];
+      StandardOutPath = "/dev/null";
+      StandardErrorPath = "/dev/null";
+    };
+  };
 
   imports = [
     ../../modules/darwin/karabiner.nix

--- a/modules/shared/agents.nix
+++ b/modules/shared/agents.nix
@@ -20,6 +20,7 @@
       customPackages.claude-code-sandboxed
       customPackages.codex-bin
       customPackages.gemini-cli-workforce
+      customPackages.opencode-sandboxed
     ];
 
   home.file =
@@ -90,5 +91,15 @@
 
       # GitHub Copilot settings
       ".copilot/skills" = agentSkills;
+
+      # opencode settings (XDG-style location)
+      ".config/opencode/opencode.json" = {
+        source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/opencode/opencode.json";
+        force = true;
+      };
+      ".config/opencode/permissive-open.sb" = {
+        source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/agents/permissive-open.sb";
+        force = true;
+      };
     };
 }

--- a/packages/claude-code-bin/default.nix
+++ b/packages/claude-code-bin/default.nix
@@ -1,20 +1,21 @@
 # Claude Code native binary fetched from Google Cloud Storage, managed independently of nixpkgs.
-# Requires --impure flag for builtins.fetchurl (no hash verification).
 #
-# Update workflow: update `version` below, then deploy.
+# Update workflow: update `version` and `hash` below, then deploy.
 {
+  fetchurl,
   lib,
   stdenvNoCC,
 }:
 let
-  version = "2.1.112";
-  baseUrl = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
-  platformKey = "darwin-arm64";
+  version = "2.1.118";
+  src = fetchurl {
+    url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${version}/darwin-arm64/claude";
+    hash = "sha256-VOXT9lEJuJxgRvR0QJRNUpBsZi0eUXSPYgpDDSatNmU=";
+  };
 in
 stdenvNoCC.mkDerivation {
   pname = "claude-code-bin";
-  inherit version;
-  src = builtins.fetchurl "${baseUrl}/${version}/${platformKey}/claude";
+  inherit version src;
   dontUnpack = true;
   dontBuild = true;
   dontStrip = true;

--- a/packages/codex-bin/default.nix
+++ b/packages/codex-bin/default.nix
@@ -1,4 +1,5 @@
 # Codex CLI native binary fetched from GitHub Releases, managed independently of nixpkgs.
+#
 # Update workflow: update `version` and `hash` below, then deploy.
 {
   fetchurl,
@@ -6,17 +7,16 @@
   stdenvNoCC,
 }:
 let
-  version = "0.122.0";
+  version = "0.124.0";
   asset = "codex-aarch64-apple-darwin";
   src = fetchurl {
     url = "https://github.com/openai/codex/releases/download/rust-v${version}/${asset}.tar.gz";
-    hash = "sha256-dOaIXhpY148CSfrtEm62qyIPnONOdiP55BCCVQNdYcw=";
+    hash = "sha256-ceh0SUR5HKi+IrmlGx8RFK+bBdbc0pkW5T85YevlKc4=";
   };
 in
 stdenvNoCC.mkDerivation {
   pname = "codex-bin";
   inherit version src;
-  # The upstream tarball expands to a single binary at archive root.
   sourceRoot = ".";
   dontBuild = true;
   dontStrip = true;

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -12,4 +12,8 @@ rec {
   gemini-cli-workforce = pkgs.callPackage ./gemini-cli-workforce {
     inherit gemini-cli-bin;
   };
+  opencode-bin = pkgs.callPackage ./opencode-bin { };
+  opencode-sandboxed = pkgs.callPackage ./opencode-sandboxed {
+    inherit opencode-bin;
+  };
 }

--- a/packages/gemini-cli-bin/default.nix
+++ b/packages/gemini-cli-bin/default.nix
@@ -1,20 +1,24 @@
-# Pre-bundled Gemini CLI fetched from npm, managed independently of nixpkgs.
-# Requires --impure flag for builtins.fetchurl (no hash verification).
+# Gemini CLI bundle fetched from npm, managed independently of nixpkgs.
 #
-# Update workflow: update `version` below, then deploy.
+# Update workflow: update `version` and `hash` below, then deploy.
 {
+  fetchurl,
   lib,
   stdenvNoCC,
   nodejs_22,
 }:
 let
-  version = "0.38.2";
+  version = "0.39.0";
+  src = fetchurl {
+    url = "https://registry.npmjs.org/@google/gemini-cli/-/gemini-cli-${version}.tgz";
+    hash = "sha256-iwCTMl/Woxb6Jzsqe5yY/w1xSwVgrh/Ug2OwA8mT0Mg=";
+  };
 in
 stdenvNoCC.mkDerivation {
   pname = "gemini-cli-bin";
-  inherit version;
-  src = builtins.fetchurl "https://registry.npmjs.org/@google/gemini-cli/-/gemini-cli-${version}.tgz";
+  inherit version src;
   dontBuild = true;
+  dontStrip = true;
   installPhase = ''
     runHook preInstall
     mkdir -p $out/share/gemini-cli $out/bin
@@ -27,6 +31,7 @@ stdenvNoCC.mkDerivation {
   meta = {
     description = "Pre-bundled Gemini CLI (npm @google/gemini-cli), version-pinned";
     license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     mainProgram = "gemini";
     platforms = lib.platforms.unix;
   };

--- a/packages/opencode-bin/default.nix
+++ b/packages/opencode-bin/default.nix
@@ -1,0 +1,34 @@
+# opencode (sst/opencode) CLI native binary fetched from GitHub Releases, managed independently of nixpkgs.
+#
+# Upstream ships rapid releases (often multiple per day); nixpkgs lags significantly.
+# Update workflow: update `version` and `hash` below, then deploy.
+{
+  fetchurl,
+  lib,
+  stdenvNoCC,
+  unzip,
+}:
+let
+  version = "1.14.22";
+  asset = "opencode-darwin-arm64";
+  src = fetchurl {
+    url = "https://github.com/sst/opencode/releases/download/v${version}/${asset}.zip";
+    hash = "sha256-zeqDvk2eEvD7SyFosSLwGj0CQ1k8r07IEEHF5tcX+Po=";
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "opencode-bin";
+  inherit version src;
+  sourceRoot = ".";
+  nativeBuildInputs = [ unzip ];
+  dontBuild = true;
+  dontStrip = true;
+  installPhase = "install -Dm755 opencode $out/bin/opencode";
+  meta = {
+    description = "Pre-built opencode (sst/opencode) CLI binary (darwin-arm64), version-pinned";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "opencode";
+    platforms = [ "aarch64-darwin" ];
+  };
+}

--- a/packages/opencode-sandboxed/default.nix
+++ b/packages/opencode-sandboxed/default.nix
@@ -1,0 +1,47 @@
+# Sandboxed opencode CLI wrapping the version-pinned opencode-bin.
+#
+# Binary version lives in packages/opencode-bin/default.nix.
+{
+  lib,
+  opencode-bin,
+  writeShellScriptBin,
+  procps,
+  ripgrep,
+  jq,
+}:
+let
+  sandboxProfilePath = "\${HOME}/.config/opencode/permissive-open.sb";
+in
+writeShellScriptBin "opencode" ''
+  export PATH="${
+    lib.makeBinPath [
+      procps
+      ripgrep
+      jq
+    ]
+  }:$PATH"
+
+  OPENCODE_BIN="${opencode-bin}/bin/opencode"
+
+  # --no-sandbox: bypass sandbox and execute the binary directly.
+  # Useful when invoked from an already-sandboxed context.
+  if [ "''${1:-}" = "--no-sandbox" ]; then
+      shift
+      exec "$OPENCODE_BIN" "$@"
+  fi
+
+  if [ ! -f "${sandboxProfilePath}" ]; then
+      echo "Error: Sandbox policy not found at ${sandboxProfilePath}" >&2
+      echo "Please ensure agent configuration is properly installed." >&2
+      exit 1
+  fi
+
+  case " $* " in
+      *" --version "*|*" --help "*|*" -h "*) ;;
+      *)
+          echo "Running opencode with macOS Seatbelt (permissive-open)" >&2
+          ;;
+  esac
+
+  exec /usr/bin/sandbox-exec -f "${sandboxProfilePath}" -D TARGET_DIR="$(pwd)" -D HOME_DIR="$HOME" "$OPENCODE_BIN" "$@"
+''


### PR DESCRIPTION


## Why
The `private` host had no local inference path, so every agent-CLI session depended on cloud APIs with their rate limits, network requirements, and data-egress constraints. 32 GB M2 Pro hardware can host a 30B-class MoE comfortably, and we wanted a local Agent-CLI backend as a fallback and as a sandbox for experimenting with OSS models without consuming cloud quota.

## What
- Chose Ollama over raw `llama.cpp` / `mlx-lm`. On a client laptop the management layer (model pull/tag, OpenAI + Anthropic-compatible endpoints, `keep_alive` handling) outweighs the small overhead savings, so switching runtimes was intentionally rejected.
- Picked Qwen3.6 35B MoE (active 3B) at Q4_K_M as the sole model, then wrapped it in a tiny derivative (`qwen3.6-full`) that forces `num_gpu=41`. Without that override Ollama left the output layer on CPU, turning every decoded token into a CPU round trip; forcing full GPU offload keeps decode steady around 15 tok/s on M2 Pro.
- Sized the resident footprint to fit in Metal: `KV_CACHE_TYPE=q8_0` plus `FLASH_ATTENTION=1` keep 32K context at ~1.9 GiB KV, so weights + KV + compute graph land at ~24.6 GiB inside the 25 GiB Metal envelope. `MAX_LOADED_MODELS=1` is mandatory, not optional tuning, to prevent thrashing under other memory pressure.
- Ran Ollama as a user-scope `launchd` agent bound to `127.0.0.1:11434` with `ThrottleInterval=30` for crash-loop guarding, plus a second agent that truncates oversized log files weekly (launchd has no built-in rotation).
- Front-ended the stack with `sst/opencode`. Upstream ships multiple releases per day, so nixpkgs lag is material; the repo carries its own version-pinned `opencode-bin` fetched straight from GitHub Releases and a sandboxed wrapper that reuses the existing shared seatbelt profile, mirroring the Claude Code / Codex / Gemini pattern.
- Kept Codex CLI on cloud default. Mixing local and cloud providers in one CLI muddies the config surface; OpenCode is the single local surface while Codex stays on `gpt-5.4`.
- Declared the Qwen3.6 derivative as a Modelfile in-repo so fresh machines reconstruct the tag via a single `ollama create -f …` documented in the README, rather than relying on imperative state under `~/.ollama`.
- Piggy-backed version bumps on the pinned agent-CLI binaries (`claude-code-bin`, `codex-bin`, `gemini-cli-bin`) since they were due.

## References
N/A
