### PR TITLE
Rework local LLM stack: MoE, on-demand, menu-bar control

### DIFF
--- a/config/ollama/modelfiles/qwen3.6-full.Modelfile
+++ b/config/ollama/modelfiles/qwen3.6-full.Modelfile
@@ -1,2 +1,0 @@
-FROM qwen3.6:35b-a3b-q4_K_M
-PARAMETER num_gpu 41

--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -6,51 +6,84 @@
     "bash": "ask",
     "edit": "ask",
     "read": "allow",
-    "webfetch": "ask"
+    "webfetch": "ask",
+    "task": "ask"
   },
   "mcp": {
     "voicevox": {
       "type": "local",
       "command": ["voicevox-mcp-server"],
       "timeout": 120000
-    },
-    "serena": {
-      "type": "local",
-      "command": [
-        "serena",
-        "start-mcp-server",
-        "--context",
-        "oaicompat-agent",
-        "--project-from-cwd",
-        "--enable-web-dashboard",
-        "False",
-        "--enable-gui-log-window",
-        "False"
-      ],
-      "environment": {
-        "SERENA_HOME": ".serena"
-      }
     }
   },
   "provider": {
-    "ollama-local": {
+    "llamacpp-local": {
       "npm": "@ai-sdk/openai-compatible",
-      "name": "Ollama (local)",
+      "name": "llama.cpp (local)",
       "options": {
-        "baseURL": "http://127.0.0.1:11434/v1"
+        "baseURL": "http://127.0.0.1:8080/v1"
       },
       "models": {
-        "qwen3.6-full": {
-          "name": "Qwen3.6 35B MoE Q4 full-GPU (local)",
+        "qwen3.6-35b-a3b": {
+          "name": "Qwen3.6 35B-A3B MoE UD-IQ4_XS (local)",
           "tool_call": true,
           "reasoning": true,
           "limit": {
-            "context": 32768,
+            "context": 65536,
             "output": 8192
           }
         }
       }
     }
   },
-  "model": "ollama-local/qwen3.6-full"
+  "agent": {
+    "plan": {
+      "description": "Use only for non-trivial changes: unfamiliar subsystem, multi-file edits, unclear design, or risky behavior changes. Read code, identify existing patterns/utilities, and return a concise implementation plan. Do not edit files.",
+      "mode": "subagent",
+      "steps": 10,
+      "temperature": 0.1,
+      "permission": {
+        "read": "allow",
+        "grep": "allow",
+        "glob": "allow",
+        "list": "allow",
+        "edit": "deny",
+        "webfetch": "ask",
+        "task": "deny",
+        "bash": {
+          "*": "deny",
+          "git grep *": "allow",
+          "git ls-files": "allow",
+          "git ls-files *": "allow"
+        }
+      }
+    },
+    "review": {
+      "description": "Read-only code reviewer. Inspect the current git diff first, then read touched files as needed. Flag correctness risks, regressions, security issues, and missing tests. Do not edit files.",
+      "mode": "subagent",
+      "steps": 8,
+      "temperature": 0.1,
+      "permission": {
+        "read": "allow",
+        "grep": "allow",
+        "glob": "allow",
+        "list": "allow",
+        "edit": "deny",
+        "webfetch": "deny",
+        "task": "deny",
+        "bash": {
+          "*": "deny",
+          "git status": "allow",
+          "git status *": "allow",
+          "git diff": "allow",
+          "git diff *": "allow",
+          "git log": "allow",
+          "git log *": "allow",
+          "git show": "allow",
+          "git show *": "allow"
+        }
+      }
+    }
+  },
+  "model": "llamacpp-local/qwen3.6-35b-a3b"
 }

--- a/config/swiftbar/llama-server.5s.sh
+++ b/config/swiftbar/llama-server.5s.sh
@@ -10,7 +10,7 @@ PATH=/usr/bin:/bin:/usr/sbin:/sbin
 UID_NUM=$(id -u)
 LABEL="gui/${UID_NUM}/org.nix-community.home.llama-server"
 HEALTH=$(curl -sS --max-time 1 http://127.0.0.1:8080/health 2>/dev/null || echo "")
-PID=$(pgrep -f "llama-server" 2>/dev/null | head -1 || true)
+PID=$(pgrep -x "llama-server" 2>/dev/null | head -1 || true)
 
 STATE="stopped"
 MEM_GB="?"

--- a/config/swiftbar/llama-server.5s.sh
+++ b/config/swiftbar/llama-server.5s.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# <bitbar.title>llama-server</bitbar.title>
+# <bitbar.author>nix-config</bitbar.author>
+# <bitbar.desc>Status & control for the local llama-server (org.nix-community.home.llama-server)</bitbar.desc>
+# <bitbar.dependencies>bash, curl, launchctl</bitbar.dependencies>
+
+set -u
+PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+UID_NUM=$(id -u)
+LABEL="gui/${UID_NUM}/org.nix-community.home.llama-server"
+HEALTH=$(curl -sS --max-time 1 http://127.0.0.1:8080/health 2>/dev/null || echo "")
+PID=$(pgrep -f "llama-server" 2>/dev/null | head -1 || true)
+
+STATE="stopped"
+MEM_GB="?"
+
+if echo "$HEALTH" | grep -q '"status":"ok"'; then
+    STATE="running"
+    if [ -n "${PID:-}" ]; then
+        MEM_KB=$(ps -o rss= -p "$PID" 2>/dev/null | tr -d ' ' || true)
+        if [ -n "${MEM_KB:-}" ]; then
+            MEM_GB=$(awk "BEGIN { printf \"%.1f\", ${MEM_KB} / 1024 / 1024 }")
+        fi
+    fi
+elif echo "$HEALTH" | grep -qE 'Loading model|unavailable_error'; then
+    STATE="loading"
+fi
+
+# Menu bar line — SF Symbol "brain.fill" only. Memory size is shown in the
+# dropdown, not on the menu bar itself.
+case "$STATE" in
+    running) echo " | sfimage=brain.fill sfcolor=#FF2D55" ;;
+    loading) echo " | sfimage=brain.fill sfcolor=#FF2D55" ;;
+    stopped) echo " | sfimage=brain.fill sfcolor=#8E8E93" ;;
+esac
+
+echo "---"
+
+# Dropdown
+case "$STATE" in
+    running)
+        echo "Status: running (pid $PID)"
+        echo "Memory: ${MEM_GB} GiB RSS"
+        echo "Endpoint: http://127.0.0.1:8080"
+        echo "---"
+        echo "Stop | bash=/bin/launchctl param1=kill param2=SIGTERM param3=$LABEL terminal=false refresh=true"
+        echo "Restart | bash=/bin/launchctl param1=kickstart param2=-k param3=$LABEL terminal=false refresh=true"
+        ;;
+    loading)
+        echo "Status: loading model…"
+        [ -n "${PID:-}" ] && echo "PID: $PID"
+        echo "---"
+        echo "Stop | bash=/bin/launchctl param1=kill param2=SIGTERM param3=$LABEL terminal=false refresh=true"
+        ;;
+    stopped)
+        echo "Status: stopped"
+        echo "---"
+        echo "Start | bash=/bin/launchctl param1=kickstart param2=$LABEL terminal=false refresh=true"
+        ;;
+esac
+
+echo "---"
+echo "Open log | bash=/usr/bin/open param1=$HOME/Library/Logs/llama-server/stderr.log terminal=false"
+echo "Refresh | refresh=true"

--- a/home/private/default.nix
+++ b/home/private/default.nix
@@ -1,6 +1,5 @@
 {
   pkgs,
-  config,
   userName,
   homeDirectory,
   ...
@@ -12,10 +11,6 @@
     username = userName;
     inherit homeDirectory;
     stateVersion = "25.11";
-
-    activation.createOllamaLogDir = config.lib.dag.entryAfter [ "writeBoundary" ] ''
-      run mkdir -p "${homeDirectory}/Library/Logs/ollama"
-    '';
   };
 
   targets.darwin.copyApps = {
@@ -26,76 +21,17 @@
   home.packages = with pkgs; [
     discord
     iina
-    ollama
     ripgrep
     slack
     zoom-us
   ];
-
-  launchd.agents.ollama = {
-    enable = true;
-    config = {
-      ProgramArguments = [
-        "${pkgs.ollama}/bin/ollama"
-        "serve"
-      ];
-      RunAtLoad = true;
-      KeepAlive = true;
-      ThrottleInterval = 30;
-      StandardOutPath = "${homeDirectory}/Library/Logs/ollama/stdout.log";
-      StandardErrorPath = "${homeDirectory}/Library/Logs/ollama/stderr.log";
-      EnvironmentVariables = {
-        OLLAMA_HOST = "127.0.0.1:11434";
-        OLLAMA_KEEP_ALIVE = "5m";
-        OLLAMA_MAX_LOADED_MODELS = "1";
-        OLLAMA_FLASH_ATTENTION = "1";
-        OLLAMA_KV_CACHE_TYPE = "q8_0";
-      };
-    };
-  };
-
-  # Weekly truncate of Ollama logs (launchd has no built-in rotation).
-  # `: > $f` on its own leaves the file sparse because `ollama serve` keeps
-  # the write fd open and retains its offset. Kickstart the agent first so
-  # the process closes its log fds, then truncate.
-  launchd.agents.ollama-log-rotate = {
-    enable = true;
-    config = {
-      ProgramArguments = [
-        "/bin/sh"
-        "-c"
-        ''
-          rotate=0
-          for f in "${homeDirectory}/Library/Logs/ollama/"*.log; do
-            [ -f "$f" ] || continue
-            size=$(/usr/bin/stat -f%z "$f" 2>/dev/null || echo 0)
-            [ "$size" -gt 52428800 ] && rotate=1
-          done
-          if [ "$rotate" -eq 1 ]; then
-            /bin/launchctl kickstart -k "gui/$(/usr/bin/id -u)/org.nix-community.home.ollama" 2>/dev/null || true
-            for f in "${homeDirectory}/Library/Logs/ollama/"*.log; do
-              [ -f "$f" ] && : > "$f"
-            done
-          fi
-        ''
-      ];
-      StartCalendarInterval = [
-        {
-          Weekday = 0;
-          Hour = 2;
-          Minute = 0;
-        }
-      ];
-      StandardOutPath = "/dev/null";
-      StandardErrorPath = "/dev/null";
-    };
-  };
 
   imports = [
     ../../modules/darwin/karabiner.nix
     ../../modules/shared/agents.nix
     ../../modules/shared/extra.nix
     ../../modules/shared/git.nix
+    ../../modules/shared/llm.nix
     ../../modules/shared/neovim.nix
     ../../modules/shared/ssh.nix
     ../../modules/shared/terminal.nix

--- a/modules/shared/llm.nix
+++ b/modules/shared/llm.nix
@@ -7,132 +7,136 @@
 }:
 
 {
-  home.packages = with pkgs; [
-    llama-cpp
-    swiftbar
-  ];
+  home = {
+    packages = with pkgs; [
+      llama-cpp
+      swiftbar
+    ];
 
-  home.activation.createLlmDirectories = config.lib.dag.entryAfter [ "writeBoundary" ] ''
-    run mkdir -p "${homeDirectory}/Library/Logs/llama-server"
-    run mkdir -p "${homeDirectory}/Library/Logs/llm"
-    run mkdir -p "${homeDirectory}/Library/Logs/swiftbar"
-    run mkdir -p "${homeDirectory}/.cache/llama-server-slots"
-    run mkdir -p "${homeDirectory}/Library/Application Support/SwiftBar/Plugins"
-  '';
+    activation.createLlmDirectories = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+      run mkdir -p "${homeDirectory}/Library/Logs/llama-server"
+      run mkdir -p "${homeDirectory}/Library/Logs/llm"
+      run mkdir -p "${homeDirectory}/Library/Logs/swiftbar"
+      run mkdir -p "${homeDirectory}/.cache/llama-server-slots"
+      run mkdir -p "${homeDirectory}/Library/Application Support/SwiftBar/Plugins"
+    '';
 
-  # Menu-bar control plugin for the on-demand llama-server. SwiftBar
-  # discovers plugins from `~/Library/Application Support/SwiftBar/Plugins`
-  # by default; the file name `*.5s.sh` triggers a 5-second refresh.
-  home.file."Library/Application Support/SwiftBar/Plugins/llama-server.5s.sh" = {
-    source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/swiftbar/llama-server.5s.sh";
-    force = true;
-  };
-
-  # Auto-start SwiftBar on login so the menu-bar control plugin is always
-  # available without manually opening the .app each session.
-  launchd.agents.swiftbar = {
-    enable = true;
-    config = {
-      ProgramArguments = [
-        "${pkgs.swiftbar}/Applications/SwiftBar.app/Contents/MacOS/SwiftBar"
-      ];
-      RunAtLoad = true;
-      KeepAlive = true;
-      ThrottleInterval = 30;
-      StandardOutPath = "${homeDirectory}/Library/Logs/swiftbar/stdout.log";
-      StandardErrorPath = "${homeDirectory}/Library/Logs/swiftbar/stderr.log";
+    # Menu-bar control plugin for the on-demand llama-server. SwiftBar
+    # discovers plugins from `~/Library/Application Support/SwiftBar/Plugins`
+    # by default; the file name `*.5s.sh` triggers a 5-second refresh.
+    file."Library/Application Support/SwiftBar/Plugins/llama-server.5s.sh" = {
+      source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/swiftbar/llama-server.5s.sh";
+      force = true;
     };
   };
 
-  # llama-server hosts Qwen3.6-35B-A3B (MoE, 3B active) for OpenCode.
-  # On-demand because the 22 GiB resident model would otherwise pin unified
-  # memory; SwiftBar plugin (config/swiftbar/) exposes menu-bar Start/Stop.
-  # Sparse attention (full_attention_interval=4, 10/40 layers full) keeps
-  # q8 KV at 64k under ~700 MiB on Metal. `--flash-attn on` is required
-  # with quantized KV, else dequantize round-trips erase the savings.
-  # `--no-mmproj` skips the bundled vision projector. `--slot-save-path`
-  # only exposes /slots/X?action=save|restore — prefix caches must be
-  # persisted explicitly, not on shutdown. Speculative decoding is
-  # unsupported: the model's Mamba SSM state cannot be rolled back on
-  # draft rejection.
-  launchd.agents.llama-server = {
-    enable = true;
-    config = {
-      ProgramArguments = [
-        "${pkgs.llama-cpp}/bin/llama-server"
-        "-hf"
-        "unsloth/Qwen3.6-35B-A3B-GGUF:UD-IQ4_XS"
-        "--no-mmproj"
-        "--alias"
-        "qwen3.6-35b-a3b"
-        "-c"
-        "65536"
-        "-ngl"
-        "99"
-        "--flash-attn"
-        "on"
-        "--cache-type-k"
-        "q8_0"
-        "--cache-type-v"
-        "q8_0"
-        "--cache-reuse"
-        "256"
-        "--slot-save-path"
-        "${homeDirectory}/.cache/llama-server-slots"
-        "--host"
-        "127.0.0.1"
-        "--port"
-        "8080"
-        "--temp"
-        "0.6"
-        "--top-p"
-        "0.95"
-        "--top-k"
-        "20"
-        "--presence-penalty"
-        "1.5"
-        "--min-p"
-        "0.00"
-        "--jinja"
-      ];
-      RunAtLoad = false;
-      KeepAlive = false;
-      ThrottleInterval = 30;
-      StandardOutPath = "${homeDirectory}/Library/Logs/llama-server/stdout.log";
-      StandardErrorPath = "${homeDirectory}/Library/Logs/llama-server/stderr.log";
+  launchd.agents = {
+    # Auto-start SwiftBar on login so the menu-bar control plugin is always
+    # available without manually opening the .app each session.
+    swiftbar = {
+      enable = true;
+      config = {
+        ProgramArguments = [
+          "${pkgs.swiftbar}/Applications/SwiftBar.app/Contents/MacOS/SwiftBar"
+        ];
+        RunAtLoad = true;
+        KeepAlive = true;
+        ThrottleInterval = 30;
+        StandardOutPath = "${homeDirectory}/Library/Logs/swiftbar/stdout.log";
+        StandardErrorPath = "${homeDirectory}/Library/Logs/swiftbar/stderr.log";
+      };
     };
-  };
 
-  # Monthly HF cache visibility snapshot. Logs total + per-model size so
-  # growth is easy to spot. Auto-deletion is intentionally NOT done: the
-  # HF cache uses a `blobs/` + `snapshots/` symlink layout where blunt
-  # mtime-based pruning can break references for revisions still in use.
-  # Cleanup is manual via `huggingface-cli delete-cache` or by removing
-  # whole `models--<org>--<repo>` dirs (each is self-contained).
-  launchd.agents.llm-disk-gc = {
-    enable = true;
-    config = {
-      ProgramArguments = [
-        "/bin/sh"
-        "-c"
-        ''
-          out="${homeDirectory}/Library/Logs/llm/disk-$(/bin/date +%Y-%m).log"
+    # llama-server hosts Qwen3.6-35B-A3B (MoE, 3B active) for OpenCode.
+    # On-demand because the 22 GiB resident model would otherwise pin unified
+    # memory; SwiftBar plugin (config/swiftbar/) exposes menu-bar Start/Stop.
+    # Sparse attention (full_attention_interval=4, 10/40 layers full) keeps
+    # q8 KV at 64k under ~700 MiB on Metal. `--flash-attn on` is required
+    # with quantized KV, else dequantize round-trips erase the savings.
+    # `--no-mmproj` skips the bundled vision projector. `--slot-save-path`
+    # only exposes /slots/X?action=save|restore — prefix caches must be
+    # persisted explicitly, not on shutdown. Speculative decoding is
+    # unsupported: the model's Mamba SSM state cannot be rolled back on
+    # draft rejection.
+    llama-server = {
+      enable = true;
+      config = {
+        ProgramArguments = [
+          "${pkgs.llama-cpp}/bin/llama-server"
+          "-hf"
+          "unsloth/Qwen3.6-35B-A3B-GGUF:UD-IQ4_XS"
+          "--no-mmproj"
+          "--alias"
+          "qwen3.6-35b-a3b"
+          "-c"
+          "65536"
+          "-ngl"
+          "99"
+          "--flash-attn"
+          "on"
+          "--cache-type-k"
+          "q8_0"
+          "--cache-type-v"
+          "q8_0"
+          "--cache-reuse"
+          "256"
+          "--slot-save-path"
+          "${homeDirectory}/.cache/llama-server-slots"
+          "--host"
+          "127.0.0.1"
+          "--port"
+          "8080"
+          "--temp"
+          "0.6"
+          "--top-p"
+          "0.95"
+          "--top-k"
+          "20"
+          "--presence-penalty"
+          "1.5"
+          "--min-p"
+          "0.00"
+          "--jinja"
+        ];
+        RunAtLoad = false;
+        KeepAlive = false;
+        ThrottleInterval = 30;
+        StandardOutPath = "${homeDirectory}/Library/Logs/llama-server/stdout.log";
+        StandardErrorPath = "${homeDirectory}/Library/Logs/llama-server/stderr.log";
+      };
+    };
+
+    # Monthly HF cache visibility snapshot. Logs total + per-model size so
+    # growth is easy to spot. Auto-deletion is intentionally NOT done: the
+    # HF cache uses a `blobs/` + `snapshots/` symlink layout where blunt
+    # mtime-based pruning can break references for revisions still in use.
+    # Cleanup is manual via `huggingface-cli delete-cache` or by removing
+    # whole `models--<org>--<repo>` dirs (each is self-contained).
+    llm-disk-snapshot = {
+      enable = true;
+      config = {
+        ProgramArguments = [
+          "/bin/sh"
+          "-c"
+          ''
+            out="${homeDirectory}/Library/Logs/llm/disk-snapshot-$(/bin/date +%Y-%m).log"
+            {
+              echo "=== $(/bin/date) ==="
+              /usr/bin/du -sh "${homeDirectory}/.cache/huggingface/hub" 2>&1 || true
+              /usr/bin/du -sh "${homeDirectory}/.cache/huggingface/hub/models--"* 2>/dev/null || true
+            } >> "$out"
+          ''
+        ];
+        StartCalendarInterval = [
           {
-            echo "=== $(/bin/date) ==="
-            /usr/bin/du -sh "${homeDirectory}/.cache/huggingface/hub" 2>&1 || true
-            /usr/bin/du -sh "${homeDirectory}/.cache/huggingface/hub/models--"* 2>/dev/null || true
-          } >> "$out"
-        ''
-      ];
-      StartCalendarInterval = [
-        {
-          Day = 1;
-          Hour = 4;
-          Minute = 0;
-        }
-      ];
-      StandardOutPath = "/dev/null";
-      StandardErrorPath = "/dev/null";
+            Day = 1;
+            Hour = 4;
+            Minute = 0;
+          }
+        ];
+        StandardOutPath = "/dev/null";
+        StandardErrorPath = "/dev/null";
+      };
     };
   };
 }

--- a/modules/shared/llm.nix
+++ b/modules/shared/llm.nix
@@ -1,0 +1,138 @@
+{
+  pkgs,
+  config,
+  homeDirectory,
+  repoPath,
+  ...
+}:
+
+{
+  home.packages = with pkgs; [
+    llama-cpp
+    swiftbar
+  ];
+
+  home.activation.createLlmDirectories = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    run mkdir -p "${homeDirectory}/Library/Logs/llama-server"
+    run mkdir -p "${homeDirectory}/Library/Logs/llm"
+    run mkdir -p "${homeDirectory}/Library/Logs/swiftbar"
+    run mkdir -p "${homeDirectory}/.cache/llama-server-slots"
+    run mkdir -p "${homeDirectory}/Library/Application Support/SwiftBar/Plugins"
+  '';
+
+  # Menu-bar control plugin for the on-demand llama-server. SwiftBar
+  # discovers plugins from `~/Library/Application Support/SwiftBar/Plugins`
+  # by default; the file name `*.5s.sh` triggers a 5-second refresh.
+  home.file."Library/Application Support/SwiftBar/Plugins/llama-server.5s.sh" = {
+    source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/swiftbar/llama-server.5s.sh";
+    force = true;
+  };
+
+  # Auto-start SwiftBar on login so the menu-bar control plugin is always
+  # available without manually opening the .app each session.
+  launchd.agents.swiftbar = {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.swiftbar}/Applications/SwiftBar.app/Contents/MacOS/SwiftBar"
+      ];
+      RunAtLoad = true;
+      KeepAlive = true;
+      ThrottleInterval = 30;
+      StandardOutPath = "${homeDirectory}/Library/Logs/swiftbar/stdout.log";
+      StandardErrorPath = "${homeDirectory}/Library/Logs/swiftbar/stderr.log";
+    };
+  };
+
+  # llama-server hosts Qwen3.6-35B-A3B (MoE, 3B active) for OpenCode.
+  # On-demand because the 22 GiB resident model would otherwise pin unified
+  # memory; SwiftBar plugin (config/swiftbar/) exposes menu-bar Start/Stop.
+  # Sparse attention (full_attention_interval=4, 10/40 layers full) keeps
+  # q8 KV at 64k under ~700 MiB on Metal. `--flash-attn on` is required
+  # with quantized KV, else dequantize round-trips erase the savings.
+  # `--no-mmproj` skips the bundled vision projector. `--slot-save-path`
+  # only exposes /slots/X?action=save|restore — prefix caches must be
+  # persisted explicitly, not on shutdown. Speculative decoding is
+  # unsupported: the model's Mamba SSM state cannot be rolled back on
+  # draft rejection.
+  launchd.agents.llama-server = {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.llama-cpp}/bin/llama-server"
+        "-hf"
+        "unsloth/Qwen3.6-35B-A3B-GGUF:UD-IQ4_XS"
+        "--no-mmproj"
+        "--alias"
+        "qwen3.6-35b-a3b"
+        "-c"
+        "65536"
+        "-ngl"
+        "99"
+        "--flash-attn"
+        "on"
+        "--cache-type-k"
+        "q8_0"
+        "--cache-type-v"
+        "q8_0"
+        "--cache-reuse"
+        "256"
+        "--slot-save-path"
+        "${homeDirectory}/.cache/llama-server-slots"
+        "--host"
+        "127.0.0.1"
+        "--port"
+        "8080"
+        "--temp"
+        "0.6"
+        "--top-p"
+        "0.95"
+        "--top-k"
+        "20"
+        "--presence-penalty"
+        "1.5"
+        "--min-p"
+        "0.00"
+        "--jinja"
+      ];
+      RunAtLoad = false;
+      KeepAlive = false;
+      ThrottleInterval = 30;
+      StandardOutPath = "${homeDirectory}/Library/Logs/llama-server/stdout.log";
+      StandardErrorPath = "${homeDirectory}/Library/Logs/llama-server/stderr.log";
+    };
+  };
+
+  # Monthly HF cache visibility snapshot. Logs total + per-model size so
+  # growth is easy to spot. Auto-deletion is intentionally NOT done: the
+  # HF cache uses a `blobs/` + `snapshots/` symlink layout where blunt
+  # mtime-based pruning can break references for revisions still in use.
+  # Cleanup is manual via `huggingface-cli delete-cache` or by removing
+  # whole `models--<org>--<repo>` dirs (each is self-contained).
+  launchd.agents.llm-disk-gc = {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "/bin/sh"
+        "-c"
+        ''
+          out="${homeDirectory}/Library/Logs/llm/disk-$(/bin/date +%Y-%m).log"
+          {
+            echo "=== $(/bin/date) ==="
+            /usr/bin/du -sh "${homeDirectory}/.cache/huggingface/hub" 2>&1 || true
+            /usr/bin/du -sh "${homeDirectory}/.cache/huggingface/hub/models--"* 2>/dev/null || true
+          } >> "$out"
+        ''
+      ];
+      StartCalendarInterval = [
+        {
+          Day = 1;
+          Hour = 4;
+          Minute = 0;
+        }
+      ];
+      StandardOutPath = "/dev/null";
+      StandardErrorPath = "/dev/null";
+    };
+  };
+}


### PR DESCRIPTION


## Why
The previous local LLM stack (introduced in #81) ran Qwen3.6-27B Dense always-on, pinning ~22 GiB of unified memory and pushing the rest of the system into 76 GiB of swap on M2 Pro 32GB. Throughput was 6.9 tok/s — Dense Q4 is bandwidth-bound at this hardware tier (200 GB/s caps it near 12 tok/s). Iteration on top had accumulated dead code: an Ollama daemon with no consumer, and a weekly bench job that became a silent no-op the moment the server moved to on-demand.

## What
- Swapped to Qwen3.6-35B-A3B MoE (UD-IQ4_XS). MoE's 3B active params escape the dense bandwidth ceiling, lifting throughput from 6.9 to ~27 tok/s. Added Flash Attention + q8/q8 KV (KV stays under ~700 MiB at 64K because the model uses sparse attention, only 10/40 layers carry token-length state). Skipped speculative decoding: the model is a Mamba SSM hybrid whose state cannot be cheaply rolled back on draft rejection, so llama.cpp refuses speculation regardless of flags.
- Made llama-server on-demand via a SwiftBar menu-bar plugin (polls `/health`, exposes Start/Stop/Restart). Rejected socket activation because the 5-15 s cold load would surface as IDE timeouts; explicit user action sets expectations correctly.
- Dropped Ollama (daemon, log-rotate, package, modelfiles) and `llm-bench` (silent no-op under on-demand). Considered keeping Ollama as a CLI-only fallback but no consumer existed; retention was rejected as residual config.
- HF cache GC switched to snapshot-only logging (per-model `du`). The previous mtime-based prune risked breaking the `blobs/`+`snapshots/` symlink layout; manual cleanup via `huggingface-cli` or removing whole `models--<org>--<repo>` dirs is safer.
- Extracted the LLM stack into `modules/shared/llm.nix`. Enabled OpenCode subagents (plan/review) with single-slot-aware tuning: `task: "ask"` (not `"allow"` — every subagent call serializes on the only inference slot), per-agent `steps` cap, `temperature: 0.1` for deterministic research, and a `bash` whitelist scoped to read-only git so `review` can actually inspect `git diff`.

## References
- #81
