### PR TITLE
Fix local LLM stack: status display, model source, log rotation

### DIFF
--- a/config/llama-server/wrapper.sh
+++ b/config/llama-server/wrapper.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Log rotation wrapper for llama-server. Invoked by launchd with the real
+# llama-server binary (and its arguments) as positional parameters.
+#
+# Rotation policy: keep the last 5 generations as gzip-compressed files
+# (stderr.log.1.gz ... stderr.log.5.gz). When the active log exceeds
+# MAX_BYTES, the oldest generation is dropped, the rest shift up by one,
+# and the active log is compressed into .1.gz and truncated in place.
+# Truncation is safe because launchd opens stderr.log in append mode, so
+# llama-server's subsequent writes seek to EOF (0 after truncation).
+#
+# Disk ceiling: 5 generations × ~2 MB compressed ≈ 10 MB. Reset to fresh
+# log on every llama-server start that crosses the threshold.
+
+set -u
+PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+LOG="$HOME/Library/Logs/llama-server/stderr.log"
+MAX_BYTES=$((10 * 1024 * 1024))
+
+if [ -f "$LOG" ] && [ "$(stat -f %z "$LOG")" -gt "$MAX_BYTES" ]; then
+    [ -f "$LOG.5.gz" ] && rm -f "$LOG.5.gz"
+    for i in 4 3 2 1; do
+        [ -f "$LOG.$i.gz" ] && mv "$LOG.$i.gz" "$LOG.$((i+1)).gz"
+    done
+    gzip -c "$LOG" > "$LOG.1.gz" && : > "$LOG"
+fi
+
+exec "$@"

--- a/config/llama-server/wrapper.sh
+++ b/config/llama-server/wrapper.sh
@@ -12,13 +12,18 @@
 # Disk ceiling: 5 generations × ~2 MB compressed ≈ 10 MB. Reset to fresh
 # log on every llama-server start that crosses the threshold.
 
-set -u
+set -eu
 PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
 LOG="$HOME/Library/Logs/llama-server/stderr.log"
 MAX_BYTES=$((10 * 1024 * 1024))
 
-if [ -f "$LOG" ] && [ "$(stat -f %z "$LOG")" -gt "$MAX_BYTES" ]; then
+# `stat ... || echo 0` collapses the missing-file path and the size-check into
+# a single race-free read: a delete between an `[ -f ]` test and `stat` would
+# otherwise leave the comparison with an empty string and abort the script
+# under `set -e` before `exec "$@"` runs, blocking the launchd start.
+filesize=$(stat -f %z "$LOG" 2>/dev/null || echo 0)
+if [ "$filesize" -gt "$MAX_BYTES" ]; then
     [ -f "$LOG.5.gz" ] && rm -f "$LOG.5.gz"
     for i in 4 3 2 1; do
         [ -f "$LOG.$i.gz" ] && mv "$LOG.$i.gz" "$LOG.$((i+1)).gz"

--- a/config/swiftbar/llama-server.5s.sh
+++ b/config/swiftbar/llama-server.5s.sh
@@ -11,12 +11,17 @@ UID_NUM=$(id -u)
 LABEL="gui/${UID_NUM}/org.nix-community.home.llama-server"
 HEALTH=$(curl -sS --max-time 1 http://127.0.0.1:8080/health 2>/dev/null || echo "")
 PID=$(pgrep -x "llama-server" 2>/dev/null | head -1 || true)
-DOWNLOADING=$(find "$HOME/.cache/huggingface/hub" -maxdepth 4 -name "*.downloadInProgress" 2>/dev/null | head -1)
 
 STATE="stopped"
 SUBSTATE=""
 HOST_GB="?"
 MODEL_GB="?"
+
+# Cache file for `MODEL_BYTES`. Once a process is up the mmap'd model size is
+# constant for its lifetime, but `lsof -Fn` + `stat` costs ~50-100 ms per call;
+# at a 5 s refresh that compounds. Key by PID so the cache invalidates the
+# moment a new server starts. Per-UID path so multiple users don't collide.
+MODEL_CACHE="/tmp/llama-server-model-cache.${UID_NUM}"
 
 if echo "$HEALTH" | grep -q '"status":"ok"'; then
     STATE="running"
@@ -37,18 +42,33 @@ if echo "$HEALTH" | grep -q '"status":"ok"'; then
         # which is path-with-space safe (vs. `awk '$NF'`). Match both `blobs/`
         # (HF cache layout) and `snapshots/<commit>/` (symlink-resolved path,
         # depending on macOS resolution behaviour).
-        MODEL_BYTES=$(lsof -p "$PID" -n -P -Fn 2>/dev/null \
-            | sed -n 's/^n//p' \
-            | grep -E "huggingface/hub/models--.*/(blobs|snapshots)/" \
-            | sort -u \
-            | while read -r f; do [ -f "$f" ] && stat -f "%z" "$f" 2>/dev/null; done \
-            | awk '{ sum += $1 } END { print sum+0 }')
+        MODEL_BYTES=0
+        if [ -f "$MODEL_CACHE" ]; then
+            read -r cached_pid cached_bytes < "$MODEL_CACHE" 2>/dev/null || true
+        fi
+        if [ "${cached_pid:-}" = "$PID" ] && [ -n "${cached_bytes:-}" ]; then
+            MODEL_BYTES=$cached_bytes
+        else
+            MODEL_BYTES=$(lsof -p "$PID" -n -P -Fn 2>/dev/null \
+                | sed -n 's/^n//p' \
+                | grep -E "huggingface/hub/models--.*/(blobs|snapshots)/" \
+                | sort -u \
+                | while read -r f; do [ -f "$f" ] && stat -f "%z" "$f" 2>/dev/null; done \
+                | awk '{ sum += $1 } END { print sum+0 }')
+            [ "${MODEL_BYTES:-0}" -gt 0 ] && printf "%s %s\n" "$PID" "$MODEL_BYTES" > "$MODEL_CACHE"
+        fi
         if [ "${MODEL_BYTES:-0}" -gt 0 ]; then
             MODEL_GB=$(awk "BEGIN { printf \"%.1f\", ${MODEL_BYTES} / 1024 / 1024 / 1024 }")
         fi
     fi
 elif [ -n "${PID:-}" ]; then
     STATE="loading"
+    # `find` here is gated by `PID` presence (=loading window) so it never runs
+    # while the server is up or stopped, which is when refresh cost matters.
+    # The scan still walks all `models--*` because the active model can change
+    # without restarting SwiftBar; restricting to a hard-coded repo would
+    # silently mis-classify substate after a model swap.
+    DOWNLOADING=$(find "$HOME/.cache/huggingface/hub" -maxdepth 4 -name "*.downloadInProgress" 2>/dev/null | head -1)
     if [ -n "${DOWNLOADING:-}" ]; then
         SUBSTATE="downloading"
     elif echo "$HEALTH" | grep -qE 'Loading model|unavailable_error'; then
@@ -72,7 +92,11 @@ echo "---"
 # Dropdown
 case "$STATE" in
     running)
-        echo "Status: running (pid $PID)"
+        if [ -n "${PID:-}" ]; then
+            echo "Status: running (pid $PID)"
+        else
+            echo "Status: running"
+        fi
         echo "Host:  ${HOST_GB} GiB"
         echo "Model: ${MODEL_GB} GiB (Metal)"
         echo "Endpoint: http://127.0.0.1:8080"

--- a/config/swiftbar/llama-server.5s.sh
+++ b/config/swiftbar/llama-server.5s.sh
@@ -2,7 +2,7 @@
 # <bitbar.title>llama-server</bitbar.title>
 # <bitbar.author>nix-config</bitbar.author>
 # <bitbar.desc>Status & control for the local llama-server (org.nix-community.home.llama-server)</bitbar.desc>
-# <bitbar.dependencies>bash, curl, launchctl</bitbar.dependencies>
+# <bitbar.dependencies>bash, curl, launchctl, footprint, lsof</bitbar.dependencies>
 
 set -u
 PATH=/usr/bin:/bin:/usr/sbin:/sbin
@@ -11,28 +11,53 @@ UID_NUM=$(id -u)
 LABEL="gui/${UID_NUM}/org.nix-community.home.llama-server"
 HEALTH=$(curl -sS --max-time 1 http://127.0.0.1:8080/health 2>/dev/null || echo "")
 PID=$(pgrep -x "llama-server" 2>/dev/null | head -1 || true)
+DOWNLOADING=$(find "$HOME/.cache/huggingface/hub" -maxdepth 4 -name "*.downloadInProgress" 2>/dev/null | head -1)
 
 STATE="stopped"
-MEM_GB="?"
+SUBSTATE=""
+HOST_GB="?"
+MODEL_GB="?"
 
 if echo "$HEALTH" | grep -q '"status":"ok"'; then
     STATE="running"
     if [ -n "${PID:-}" ]; then
-        MEM_KB=$(ps -o rss= -p "$PID" 2>/dev/null | tr -d ' ' || true)
-        if [ -n "${MEM_KB:-}" ]; then
-            MEM_GB=$(awk "BEGIN { printf \"%.1f\", ${MEM_KB} / 1024 / 1024 }")
+        # `ps -o rss=` requires entitlement on recent macOS; `footprint` does not
+        # and reports physical footprint (Apple's memory-pressure metric).
+        # This covers KV cache, inference buffers, heap — but NOT model weights:
+        # with `-ngl 99`, llama.cpp mmaps the GGUF and Metal pins it as GPU
+        # buffer in unified memory, which is excluded from process accounting.
+        # Read the mmap'd blob sizes from lsof to surface the hidden bulk.
+        MEM_MB=$(footprint "$PID" 2>/dev/null | sed -nE 's/.*Footprint: ([0-9]+) MB.*/\1/p' | head -1)
+        if [ -n "${MEM_MB:-}" ]; then
+            HOST_GB=$(awk "BEGIN { printf \"%.1f\", ${MEM_MB} / 1024 }")
+        fi
+        MODEL_BYTES=$(lsof -p "$PID" 2>/dev/null \
+            | awk '$NF ~ /huggingface\/hub\/models--.*\/blobs\// { print $NF }' \
+            | sort -u \
+            | while read -r f; do [ -f "$f" ] && stat -f "%z" "$f" 2>/dev/null; done \
+            | awk '{ sum += $1 } END { print sum+0 }')
+        if [ "${MODEL_BYTES:-0}" -gt 0 ]; then
+            MODEL_GB=$(awk "BEGIN { printf \"%.1f\", ${MODEL_BYTES} / 1024 / 1024 / 1024 }")
         fi
     fi
-elif echo "$HEALTH" | grep -qE 'Loading model|unavailable_error'; then
+elif [ -n "${PID:-}" ]; then
     STATE="loading"
+    if [ -n "${DOWNLOADING:-}" ]; then
+        SUBSTATE="downloading"
+    elif echo "$HEALTH" | grep -qE 'Loading model|unavailable_error'; then
+        SUBSTATE="loading model"
+    else
+        SUBSTATE="starting"
+    fi
 fi
 
-# Menu bar line — SF Symbol "brain.fill" only. Memory size is shown in the
-# dropdown, not on the menu bar itself.
+# Menu bar line — state is encoded in the symbol shape only. SwiftBar forces
+# `isTemplate = true` on `sfimage` (MenuLineParameters.swift), so `sfcolor`
+# has no effect on the rendered icon. Memory size shows in the dropdown.
 case "$STATE" in
-    running) echo " | sfimage=brain.fill sfcolor=#FF2D55" ;;
-    loading) echo " | sfimage=brain.fill sfcolor=#FF2D55" ;;
-    stopped) echo " | sfimage=brain.fill sfcolor=#8E8E93" ;;
+    running) echo " | sfimage=brain.fill" ;;
+    loading) echo " | sfimage=hourglass" ;;
+    stopped) echo " | sfimage=brain" ;;
 esac
 
 echo "---"
@@ -41,14 +66,19 @@ echo "---"
 case "$STATE" in
     running)
         echo "Status: running (pid $PID)"
-        echo "Memory: ${MEM_GB} GiB RSS"
+        echo "Host:  ${HOST_GB} GiB"
+        echo "Model: ${MODEL_GB} GiB (Metal)"
         echo "Endpoint: http://127.0.0.1:8080"
         echo "---"
         echo "Stop | bash=/bin/launchctl param1=kill param2=SIGTERM param3=$LABEL terminal=false refresh=true"
         echo "Restart | bash=/bin/launchctl param1=kickstart param2=-k param3=$LABEL terminal=false refresh=true"
         ;;
     loading)
-        echo "Status: loading model…"
+        case "$SUBSTATE" in
+            downloading) echo "Status: downloading model…" ;;
+            "loading model") echo "Status: loading model…" ;;
+            *) echo "Status: starting…" ;;
+        esac
         [ -n "${PID:-}" ] && echo "PID: $PID"
         echo "---"
         echo "Stop | bash=/bin/launchctl param1=kill param2=SIGTERM param3=$LABEL terminal=false refresh=true"

--- a/config/swiftbar/llama-server.5s.sh
+++ b/config/swiftbar/llama-server.5s.sh
@@ -27,12 +27,19 @@ if echo "$HEALTH" | grep -q '"status":"ok"'; then
         # with `-ngl 99`, llama.cpp mmaps the GGUF and Metal pins it as GPU
         # buffer in unified memory, which is excluded from process accounting.
         # Read the mmap'd blob sizes from lsof to surface the hidden bulk.
-        MEM_MB=$(footprint "$PID" 2>/dev/null | sed -nE 's/.*Footprint: ([0-9]+) MB.*/\1/p' | head -1)
-        if [ -n "${MEM_MB:-}" ]; then
-            HOST_GB=$(awk "BEGIN { printf \"%.1f\", ${MEM_MB} / 1024 }")
+        # `-f bytes` avoids unit/locale ambiguity (default `formatted` switches
+        # KB/MB/GB suffixes once the process grows past each boundary).
+        MEM_BYTES=$(footprint -f bytes "$PID" 2>/dev/null | sed -nE 's/.*Footprint:[[:space:]]+([0-9]+) B.*/\1/p' | head -1)
+        if [ -n "${MEM_BYTES:-}" ]; then
+            HOST_GB=$(awk "BEGIN { printf \"%.1f\", ${MEM_BYTES} / 1024 / 1024 / 1024 }")
         fi
-        MODEL_BYTES=$(lsof -p "$PID" 2>/dev/null \
-            | awk '$NF ~ /huggingface\/hub\/models--.*\/blobs\// { print $NF }' \
+        # `lsof -Fn` is field-mode output (one path per `n`-prefixed line),
+        # which is path-with-space safe (vs. `awk '$NF'`). Match both `blobs/`
+        # (HF cache layout) and `snapshots/<commit>/` (symlink-resolved path,
+        # depending on macOS resolution behaviour).
+        MODEL_BYTES=$(lsof -p "$PID" -n -P -Fn 2>/dev/null \
+            | sed -n 's/^n//p' \
+            | grep -E "huggingface/hub/models--.*/(blobs|snapshots)/" \
             | sort -u \
             | while read -r f; do [ -f "$f" ] && stat -f "%z" "$f" 2>/dev/null; done \
             | awk '{ sum += $1 } END { print sum+0 }')

--- a/config/swiftbar/llama-server.5s.sh
+++ b/config/swiftbar/llama-server.5s.sh
@@ -3,6 +3,11 @@
 # <bitbar.author>nix-config</bitbar.author>
 # <bitbar.desc>Status & control for the local llama-server (org.nix-community.home.llama-server)</bitbar.desc>
 # <bitbar.dependencies>bash, curl, launchctl, footprint, lsof</bitbar.dependencies>
+# <swiftbar.hideAbout>true</swiftbar.hideAbout>
+# <swiftbar.hideRunInTerminal>true</swiftbar.hideRunInTerminal>
+# <swiftbar.hideLastUpdated>true</swiftbar.hideLastUpdated>
+# <swiftbar.hideDisablePlugin>true</swiftbar.hideDisablePlugin>
+# <swiftbar.hideSwiftBar>true</swiftbar.hideSwiftBar>
 
 set -u
 PATH=/usr/bin:/bin:/usr/sbin:/sbin

--- a/modules/shared/llm.nix
+++ b/modules/shared/llm.nix
@@ -64,7 +64,7 @@
         ProgramArguments = [
           "${pkgs.llama-cpp}/bin/llama-server"
           "-hf"
-          "unsloth/Qwen3.6-35B-A3B-GGUF:UD-IQ4_XS"
+          "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF:IQ4_XS"
           "--no-mmproj"
           "--alias"
           "qwen3.6-35b-a3b"

--- a/modules/shared/llm.nix
+++ b/modules/shared/llm.nix
@@ -34,9 +34,14 @@
     # under `~/.config/` (no spaces) because launchd's home-manager-generated
     # `/bin/sh -c "wait4path ... && exec ..."` joins ProgramArguments by
     # spaces; a path with embedded whitespace would split incorrectly.
+    #
+    # Source is a path literal (NOT mkOutOfStoreSymlink) so the wrapper is
+    # copied into the Nix store. macOS TCC blocks launchd-spawned shells
+    # from traversing into `~/Documents/` (where the repo lives), causing
+    # `Operation not permitted` on exec; `/nix/store` is unrestricted.
     file.".config/llama-server/wrapper.sh" = {
-      source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/llama-server/wrapper.sh";
-      force = true;
+      source = ../../config/llama-server/wrapper.sh;
+      executable = true;
     };
   };
 

--- a/modules/shared/llm.nix
+++ b/modules/shared/llm.nix
@@ -63,6 +63,15 @@
       config = {
         ProgramArguments = [
           "${pkgs.llama-cpp}/bin/llama-server"
+          # Bartowski mirror is a pragmatic workaround, not a permanent fix:
+          # when HF migrated unsloth/Qwen3.6-35B-A3B-GGUF to Xet storage, the
+          # tree API briefly returned masked `lfs.oid` (64 asterisks) instead
+          # of valid SHA256, which llama.cpp's `is_valid_oid` rejects, causing
+          # `get_repo_files` to drop every GGUF and report "no GGUF files
+          # found". HF has since restored valid OIDs for this repo, but the
+          # next Xet-induced regression could hit any mirror — durable fix
+          # belongs upstream in llama.cpp (Xet-aware repo listing). Revisit
+          # this pin if you want the marginally smaller UD-IQ4_XS quant.
           "-hf"
           "bartowski/Qwen_Qwen3.6-35B-A3B-GGUF:IQ4_XS"
           "--no-mmproj"

--- a/modules/shared/llm.nix
+++ b/modules/shared/llm.nix
@@ -18,6 +18,7 @@
       run mkdir -p "${homeDirectory}/Library/Logs/llm"
       run mkdir -p "${homeDirectory}/Library/Logs/swiftbar"
       run mkdir -p "${homeDirectory}/.cache/llama-server-slots"
+      run mkdir -p "${homeDirectory}/.config/llama-server"
       run mkdir -p "${homeDirectory}/Library/Application Support/SwiftBar/Plugins"
     '';
 
@@ -26,6 +27,15 @@
     # by default; the file name `*.5s.sh` triggers a 5-second refresh.
     file."Library/Application Support/SwiftBar/Plugins/llama-server.5s.sh" = {
       source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/swiftbar/llama-server.5s.sh";
+      force = true;
+    };
+
+    # Log-rotation wrapper invoked by the llama-server launchd agent. Lives
+    # under `~/.config/` (no spaces) because launchd's home-manager-generated
+    # `/bin/sh -c "wait4path ... && exec ..."` joins ProgramArguments by
+    # spaces; a path with embedded whitespace would split incorrectly.
+    file.".config/llama-server/wrapper.sh" = {
+      source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/llama-server/wrapper.sh";
       force = true;
     };
   };
@@ -62,6 +72,10 @@
       enable = true;
       config = {
         ProgramArguments = [
+          # Wrapper rotates `~/Library/Logs/llama-server/stderr.log` (5
+          # gzip'd generations, 10 MiB threshold) on each start, then
+          # `exec`s its arguments. See `config/llama-server/wrapper.sh`.
+          "${homeDirectory}/.config/llama-server/wrapper.sh"
           "${pkgs.llama-cpp}/bin/llama-server"
           # Bartowski mirror is a pragmatic workaround, not a permanent fix:
           # when HF migrated unsloth/Qwen3.6-35B-A3B-GGUF to Xet storage, the


### PR DESCRIPTION


## Why
The on-demand local-LLM workflow was opaque and broken end-to-end.
The SwiftBar menu-bar plugin misreported state and memory, the
configured Hugging Face repo intermittently failed to resolve via
`-hf` due to a Xet-related API regression, and stderr.log grew
without rotation.

## What
- Switch the configured GGUF mirror as a pragmatic Xet workaround.
  Documented in-line as non-durable so the next outage points future-us
  at the upstream issue rather than at the mirror choice.
- Overhaul the SwiftBar plugin's state and memory accounting. State is
  now encoded by SF Symbol shape because SwiftBar forces template-mode
  rendering for `sfimage` (`sfcolor` is a no-op). Memory uses
  `footprint -f bytes` — the entitlement-free, locale-stable replacement
  for the now-broken `ps -o rss=` — and adds a separate `Model` line
  summing mmap'd HF cache blobs. Apple Silicon's unified memory hides
  Metal-pinned model weights from per-process accounting, so Activity
  Monitor and `ps` understate real RAM usage by the entire model size.
  Substates distinguish download / model-load / startup so a
  multi-minute download no longer falls through to `stopped`.
- Rotate stderr.log into 5 gzip'd generations (10 MiB threshold) via a
  wrapper the launchd agent invokes before exec'ing llama-server. The
  wrapper is copied into the Nix store rather than out-of-store
  symlinked, because TCC denies launchd-spawned shells access to the
  repo's location under `~/Documents/`.

## References
N/A
