### PR TITLE
Drop dangling agent commands symlink to fix Security Scan

### DIFF
--- a/modules/shared/agents.nix
+++ b/modules/shared/agents.nix
@@ -30,11 +30,6 @@
         force = true;
         recursive = true;
       };
-      agentCommands = {
-        source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/agents/commands";
-        force = true;
-        recursive = true;
-      };
       agentSkills = {
         source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/agents/skills";
         force = true;
@@ -56,7 +51,6 @@
         source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/claude/settings.json";
         force = true;
       };
-      ".claude/commands" = agentCommands;
       ".claude/scripts" = agentScripts;
       ".claude/skills" = agentSkills;
 
@@ -69,7 +63,6 @@
         source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/codex/config.toml";
         force = true;
       };
-      ".codex/prompts" = agentCommands;
       ".codex/skills" = agentSkills;
 
       # Gemini CLI settings


### PR DESCRIPTION


## Why
The Security Scan workflow has been failing because sbomnix walked the `darwin-system` closure and hit `RuntimeError: path /nix/store/...-hm_commands does not exist`. The `mkOutOfStoreSymlink` for `config/agents/commands` produced a store symlink whose target was deleted when commands were migrated to skills, leaving a broken symlink in the runtime closure that sbomnix's `os.path.exists` (which follows symlinks) reports as missing.

## What
- Treated this as a dead-reference cleanup rather than a sbomnix workaround: the upstream `config/agents/commands/` directory is intentionally gone, so the home-manager wiring that linked it into `~/.claude/commands` and `~/.codex/prompts` is the actual stale piece. Removing those entries (and the shared `agentCommands` binding) eliminates the broken symlink at the source.
- Considered recreating an empty `config/agents/commands/` placeholder to satisfy the symlink, but rejected it: it would re-introduce a directory whose contents were deliberately moved to skills, and it only masks the problem for sbomnix without restoring any user-facing functionality.
- Considered pinning or patching sbomnix in CI to tolerate broken symlinks, but rejected it: a runtime closure that contains broken symlinks is a real defect, not a scanner false positive — fixing the source keeps every closure consumer (sbomnix, grype, future tooling) honest.

## References
- #76
- #77
