### PR TITLE
Remove Local LLM section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,21 +48,6 @@ nix-collect-garbage -d && nix-store --gc
 > On macOS, if GC fails with "Operation not permitted", run from the Terminal app
 > with Full Disk Access enabled (System Settings > Privacy & Security > Full Disk Access).
 
-## Local LLM (private only)
-
-The `private` host runs Ollama as a user LaunchAgent for OpenCode backend experimentation.
-After first deploy, bootstrap the model once:
-
-```bash
-ollama pull qwen3.6:35b-a3b-q4_K_M
-ollama create qwen3.6-full -f config/ollama/modelfiles/qwen3.6-full.Modelfile
-```
-
-The derivative (`qwen3.6-full`) forces all 41 layers to GPU via
-`PARAMETER num_gpu 41`, keeping the M2 Pro 25 GiB Metal budget full-GPU and
-avoiding CPU offload on the output layer. OpenCode's model reference in
-`config/opencode/opencode.json` points at this derivative tag.
-
 ## Extra Packages (optional)
 
 Git-untracked, machine-specific configuration can be added via `~/.config/nix-extra/`.


### PR DESCRIPTION


## Why
The README's Local LLM section described Ollama-specific bootstrap steps and a `num_gpu` workaround that were tightly coupled to the original stack from #81. Subsequent reworks (#82, #83) changed the runtime and operations enough that the prose was already stale, and the level of operational detail did not belong in a top-level README aimed at newcomers.

## What
Chose outright removal over rewriting because the local LLM is supplementary to cloud-based agent workflows and not part of the core "declarative macOS environment" pitch this README makes. Keeping a shorter, updated section was considered but rejected: any version detailed enough to be useful (model tags, bootstrap commands, GPU budget notes) drifts whenever the stack is tuned, while a one-liner would not earn its place. Operational notes are better colocated with the module that owns them, leaving the README focused on setup commands, environment variables, and build requirements that apply to every host.

## References
N/A
