### PR TITLE
Add fzf and ghq with quick-cd zsh shortcut

### DIFF
--- a/modules/shared/git.nix
+++ b/modules/shared/git.nix
@@ -34,6 +34,7 @@ in
 {
   home.packages = with pkgs; [
     gh
+    ghq
     git-clean
   ];
 

--- a/modules/shared/terminal.nix
+++ b/modules/shared/terminal.nix
@@ -15,6 +15,11 @@
     nix-direnv.enable = true;
   };
 
+  programs.fzf = {
+    enable = true;
+    enableZshIntegration = true;
+  };
+
   programs.zsh = {
     enable = true;
     dotDir = "${config.xdg.configHome}/zsh";
@@ -28,6 +33,21 @@
 
       # Add user tools to PATH
       export PATH=$HOME/bin:$PATH
+    '';
+
+    initContent = ''
+      git-find() {
+        local selected
+        selected=$(ghq list | fzf --query "$*") || return 1
+        cd "$(ghq root)/$selected"
+      }
+
+      git-find-widget() {
+        BUFFER="git-find ''${(q)LBUFFER}"
+        zle accept-line
+      }
+      zle -N git-find-widget
+      bindkey '^G' git-find-widget
     '';
 
     syntaxHighlighting.enable = true;

--- a/modules/shared/terminal.nix
+++ b/modules/shared/terminal.nix
@@ -10,47 +10,49 @@
     tmux
   ];
 
-  programs.direnv = {
-    enable = true;
-    nix-direnv.enable = true;
-  };
+  programs = {
+    direnv = {
+      enable = true;
+      nix-direnv.enable = true;
+    };
 
-  programs.fzf = {
-    enable = true;
-    enableZshIntegration = true;
-  };
+    fzf = {
+      enable = true;
+      enableZshIntegration = true;
+    };
 
-  programs.zsh = {
-    enable = true;
-    dotDir = "${config.xdg.configHome}/zsh";
+    zsh = {
+      enable = true;
+      dotDir = "${config.xdg.configHome}/zsh";
 
-    envExtra = ''
-      # Nix
-      if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
-        . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
-      fi
-      # End Nix
+      envExtra = ''
+        # Nix
+        if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
+          . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+        fi
+        # End Nix
 
-      # Add user tools to PATH
-      export PATH=$HOME/bin:$PATH
-    '';
+        # Add user tools to PATH
+        export PATH=$HOME/bin:$PATH
+      '';
 
-    initContent = ''
-      git-find() {
-        local selected
-        selected=$(ghq list | fzf --query "$*") || return 1
-        cd "$(ghq root)/$selected"
-      }
+      initContent = ''
+        git-find() {
+          local selected
+          selected=$(ghq list | fzf --query "$*") || return 1
+          cd "$(ghq root)/$selected"
+        }
 
-      git-find-widget() {
-        BUFFER="git-find ''${(q)LBUFFER}"
-        zle accept-line
-      }
-      zle -N git-find-widget
-      bindkey '^G' git-find-widget
-    '';
+        git-find-widget() {
+          BUFFER="git-find ''${(q)LBUFFER}"
+          zle accept-line
+        }
+        zle -N git-find-widget
+        bindkey '^G' git-find-widget
+      '';
 
-    syntaxHighlighting.enable = true;
+      syntaxHighlighting.enable = true;
+    };
   };
 
   home.file = {

--- a/modules/shared/terminal.nix
+++ b/modules/shared/terminal.nix
@@ -39,12 +39,12 @@
       initContent = ''
         git-find() {
           local selected
-          selected=$(ghq list | fzf --query "$*") || return 1
-          cd "$(ghq root)/$selected"
+          selected=$(ghq list -p | fzf --query "$*") || return 1
+          cd "$selected"
         }
 
         git-find-widget() {
-          BUFFER="git-find ''${(q)LBUFFER}"
+          BUFFER="git-find ''${(q)BUFFER}"
           zle accept-line
         }
         zle -N git-find-widget


### PR DESCRIPTION


## Why
The configuration manages developer tooling declaratively but was missing fzf and ghq, both used daily for repository navigation. Cloning is already organized under `~/ghq`, but switching directories required typing or path-completing the full path each time, which was friction-heavy and inconsistent across machines.

## What
- Adopt the home-manager `programs.fzf` module instead of dropping the binary into `home.packages`, since the module wires up the standard zsh keybindings (Ctrl-R / Ctrl-T / Alt-C) without hand-rolled init snippets.
- Implement the ghq quick-cd as two layers: a plain zsh function (directly callable, takes an optional query argument) and a thin ZLE widget bound to a key that forwards the in-progress prompt content as the fzf query. The split is forced because the prompt buffer variable only exists inside ZLE, but keeping the underlying function callable on its own (e.g., from scripts or with explicit queries) was valuable.
- Rejected a `writeShellScriptBin` implementation: a script runs in a subshell and cannot change the parent shell's `cwd`, so cd-on-select would have required an extra wrapper, leaving the script with the trivial role of printing a path. A zsh function performs the `cd` directly and eliminates the two-piece design.
- Chose Ctrl-G for the binding. It overrides zsh's default `send-break`, but that binding is rarely used in practice (Ctrl-C aborts equivalently). Ctrl-] is more conventional in older Japanese ghq+peco/fzf tutorials, but Ctrl-G was preferred and the cost of overriding `send-break` is negligible.

## References
N/A
