### PR TITLE
Add gcloud workforce-auth wrapper and share secret tooling

### DIFF
--- a/home/private/default.nix
+++ b/home/private/default.nix
@@ -30,6 +30,7 @@
     ../../modules/darwin/karabiner.nix
     ../../modules/shared/agents.nix
     ../../modules/shared/extra.nix
+    ../../modules/shared/gcloud.nix
     ../../modules/shared/git.nix
     ../../modules/shared/llm.nix
     ../../modules/shared/neovim.nix

--- a/home/work/default.nix
+++ b/home/work/default.nix
@@ -19,7 +19,6 @@
   };
 
   home.packages = with pkgs; [
-    _1password-cli
     gmailctl
   ];
 
@@ -28,6 +27,7 @@
     ../../modules/shared/agents.nix
     ../../modules/shared/container.nix
     ../../modules/shared/extra.nix
+    ../../modules/shared/gcloud.nix
     ../../modules/shared/git.nix
     ../../modules/shared/neovim.nix
     ../../modules/shared/ssh.nix

--- a/modules/shared/gcloud.nix
+++ b/modules/shared/gcloud.nix
@@ -1,0 +1,40 @@
+{
+  pkgs,
+  ...
+}:
+
+let
+  gcloudWorkforceAuth = pkgs.writeShellApplication {
+    name = "gcloud-workforce-auth";
+    runtimeInputs = [ pkgs.google-cloud-sdk ];
+    text = ''
+      : "''${WORKFORCE_POOL_ID:?set WORKFORCE_POOL_ID via direnv}"
+      : "''${PROVIDER_ID:?set PROVIDER_ID via direnv}"
+
+      WORKFORCE_LOCATION="''${WORKFORCE_LOCATION:-global}"
+      WORKFORCE_PROVIDER="locations/$WORKFORCE_LOCATION/workforcePools/$WORKFORCE_POOL_ID/providers/$PROVIDER_ID"
+
+      GCLOUD_CONFIG_DIR="''${CLOUDSDK_CONFIG:-$HOME/.config/gcloud}"
+      LOGIN_CONFIG_FILE="$GCLOUD_CONFIG_DIR/workforce-login-config.json"
+
+      umask 077
+      mkdir -p "$GCLOUD_CONFIG_DIR"
+
+      printf 'Generating login config for %s\n' "$WORKFORCE_PROVIDER"
+      gcloud iam workforce-pools create-login-config \
+        "$WORKFORCE_PROVIDER" \
+        --output-file="$LOGIN_CONFIG_FILE" \
+        --activate
+      chmod 600 "$LOGIN_CONFIG_FILE"
+
+      gcloud auth login --login-config="$LOGIN_CONFIG_FILE"
+      gcloud auth list
+    '';
+  };
+in
+{
+  home.packages = [
+    pkgs.google-cloud-sdk
+    gcloudWorkforceAuth
+  ];
+}

--- a/modules/shared/terminal.nix
+++ b/modules/shared/terminal.nix
@@ -7,6 +7,9 @@
 
 {
   home.packages = with pkgs; [
+    _1password-cli
+    age
+    sops
     tmux
   ];
 


### PR DESCRIPTION


## Why
The `gcloud-workforce-auth` flow for signing in via Okta Workforce Identity Federation lived outside Nix as a hand-maintained shell script in `~/bin/` with deployment-specific IDs inlined. The same flow is used on both private and work profiles, so the script (and the secret-retrieval tooling that supports it) belonged in the shared home-manager modules. Auth/secret tooling was also inconsistent across profiles — `_1password-cli` was work-only despite direnv-based secret retrieval being identical on both.

## What
- Reject the option of inlining workforce/Okta IDs in Nix: even when the source is git-untracked, values baked into a derivation end up in the Nix store and home-manager generation artifacts. Runtime env-var injection via direnv keeps deployment-specific identifiers out of the store entirely.
- Wrap the script with `writeShellApplication` rather than `mkOutOfStoreSymlink`-ing a raw `.sh`: gives `set -euo pipefail`, shellcheck at build time, and `runtimeInputs` so the bundled `gcloud` is resolved deterministically regardless of the caller's PATH.
- Require only the inputs the underlying gcloud command actually consumes (`WORKFORCE_POOL_ID`, `PROVIDER_ID`); `WORKFORCE_LOCATION` defaults to `global`. The previous script also required org/Okta/client identifiers for display only — that produced a failure mode where login was blocked because non-functional values were missing.
- Belt-and-suspenders permissions on the generated login config: `umask 077` for any files we create plus explicit `chmod 600` on the gcloud output, because gcloud writes mode 644 and ignores the inherited umask.
- Promote `_1password-cli` to the shared terminal module alongside new `sops` and `age`, since both profiles use direnv-driven secret retrieval and there is no architectural reason to keep these split.

## References
N/A
