### PR TITLE
Add empirical-prompt-tuning skill and update agent CLIs/settings

### DIFF
--- a/config/agents/skills/empirical-prompt-tuning/SKILL.md
+++ b/config/agents/skills/empirical-prompt-tuning/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: empirical-prompt-tuning
+description: A method for iteratively improving agent-facing text instructions (skill / slash command / task prompt / CLAUDE.md section / code-generation prompt) by having an unbiased executor run them, then evaluating from both sides (executor self-report + instruction-side metrics). Loop until improvement plateaus. Use right after creating or significantly revising a prompt or skill, or when you suspect that an agent's failure to behave as expected stems from ambiguity on the instruction side.
+---
+
+# Empirical Prompt Tuning
+
+The author of a prompt cannot judge its quality. The clearer it feels to the writer, the more often another agent stumbles over it. **Have an unbiased executor actually run it, evaluate from both sides, and iterate** — that is the core of this skill. Do not stop until improvement plateaus.
+
+## When to use
+
+- Right after creating or significantly revising a skill / slash command / task prompt
+- When an agent does not behave as expected and you want to attribute the cause to instruction-side ambiguity
+- When hardening high-importance instructions (frequently used skills, prompts at the core of automation)
+
+When not to use:
+- One-off, throwaway prompts (the evaluation cost is not worth it)
+- When the goal is not improving success rate but reflecting the writer's subjective preference
+
+## Workflow
+
+0. **Iteration 0 — alignment check between description and body** (static, no dispatch)
+   - Read the trigger / use cases the frontmatter `description` claims
+   - Read the scope the body actually covers
+   - If they diverge, fix description or body to match before proceeding to iter 1
+   - Example: detect cases like `description` saying "navigation / form filling / data extraction" while the body only contains a `npx playwright test` CLI reference
+   - If you skip this, the subagent will "reinterpret" the body to match the description, and accuracy comes out fine even though the skill does not actually meet the requirements (false positive)
+
+1. **Baseline preparation**: fix the target prompt and prepare the following two:
+   - **Evaluation scenarios**, 2 to 3 (1 median + 1 to 2 edge). Tasks that could realistically occur, simulating situations where the target prompt is actually applied.
+   - **Requirements checklist** (for accuracy calculation). For each scenario, list 3 to 7 items the deliverable must satisfy. Accuracy % = items satisfied / total items. Fix this in advance (do not move it later).
+2. **Bias-free read**: have a "blank" executor read the instructions. **Dispatch a fresh subagent** via the Task tool. Do not settle for self-rereading (it is structurally impossible to view text you just wrote objectively). When running multiple scenarios in parallel, place multiple Agent calls in a single message. For environments where dispatch is unavailable, see the "Environment constraints" section.
+3. **Execution**: hand the subagent a prompt that follows the **subagent invocation contract** below and have it run the scenario. The executor produces an implementation or output, then returns a self-report at the end.
+4. **Two-sided evaluation**: from the returned result, record the following.
+   - **Executor self-report** (extracted from the body of the subagent's report): ambiguities / discretionary completions / spots where template application got stuck
+   - **Instruction-side metrics** (judgement rules are defined in this section as the single source of truth; other places reference back here):
+     - Success/failure: success (○) only when **all** items tagged `[critical]` are ○. If even one is × or partial, it is failure (×). Labels are binary, ○ / × only.
+     - Accuracy (achievement rate of the requirements checklist, as %. ○ = full mark, × = 0, partial = 0.5; sum and divide by total items)
+     - Step count (use the `tool_uses` value in the usage metadata returned by the Task tool as is. Include Read / Grep — do not exclude them.)
+     - Duration (`duration_ms` from the Task tool usage metadata)
+     - Retry count (how many times the subagent redid the same judgement. Extracted from the subagent's self-report; not measurable on the instruction side.)
+     - **On failure, add a one-liner under "ambiguities" in the presentation format saying which `[critical]` item dropped** (for cause tracking)
+   - The requirements checklist must contain **at least one** `[critical]`-tagged item (with zero, the success judgement becomes vacuous). Do not add or remove `[critical]` after the fact.
+5. **Apply diff**: introduce the minimal edit that closes the ambiguities into the prompt. One theme per iteration (multiple related edits are fine; unrelated edits go to the next iteration).
+6. **Re-evaluate**: dispatch a new subagent and run 2 → 5 again (do not reuse the same agent: it has learned from the previous improvement). Increase parallelism only if iterations stop producing improvement.
+7. **Convergence check**: rough rule — stop when "two consecutive iterations show zero new ambiguities AND metric improvement below the threshold (see below)". For high-importance prompts, require three consecutive.
+
+## Evaluation axes
+
+| Axis | How to take it | Meaning |
+|---|---|---|
+| Success/failure | Whether the executor produced the intended deliverable (binary) | Minimum bar |
+| Accuracy | What % of the requirements the deliverable met | Degree of partial success |
+| Step count | Number of tool calls / decision steps the executor used | Indicator of instruction waste |
+| Duration | Executor's `duration_ms` | Proxy for cognitive load |
+| Retry count | How many times the same judgement was redone | Signal of instruction ambiguity |
+| Ambiguities (self-reported) | Listed by the executor as bullet points | Qualitative material for improvement |
+| Discretionary completions (self-reported) | Decisions not specified in the instructions | Surfacing of implicit specs |
+
+**Weighting**: qualitative (ambiguities, discretionary completions) is primary; quantitative (duration, step count) is secondary. Chasing only time reduction makes the prompt overly thin.
+
+### Qualitative interpretation of `tool_uses`
+
+Looking only at accuracy hides skill-level problems. Using `tool_uses` as a **relative value across scenarios** reveals structural defects:
+
+- If one scenario is **3-5x or more** of the others, that skill leans toward a **decision-tree index with low self-containedness**. The executor is being forced into references descent.
+- Typical example: all scenarios show `tool_uses` of 1-3, but one scenario shows 15+ → the skill lacks an inline recipe for that scenario, and the executor is sweeping across `references/`.
+- Remedy: in iter 2, add a "minimal complete example inline" or "guidance on when to read references" near the top of SKILL.md, and `tool_uses` drops sharply.
+
+Even at 100% accuracy, a `tool_uses` skew is grounds to trigger iter 2. "Judging only by accuracy and stopping" tends to miss structural defects.
+
+## Subagent invocation contract
+
+The prompt handed to the executor takes the following structure. This is the input contract for "two-sided evaluation".
+
+```
+You are an executor reading <target prompt name> with a blank slate.
+
+## Target prompt
+<paste the full body of the target prompt, or specify the path to Read>
+
+## Scenario
+<one paragraph describing the scenario's situation>
+
+## Requirements checklist (items the deliverable must satisfy)
+1. [critical] <item that belongs to the minimum bar>
+2. <regular item>
+3. <regular item>
+...
+(Judgement rules are defined as the single source of truth in "Workflow 4. Two-sided evaluation / Instruction-side metrics". At least one [critical] is required.)
+
+## Task
+1. Follow the target prompt to execute the scenario and produce the deliverable.
+2. On finish, reply using the report structure below.
+
+## Report structure
+- Deliverable: <output or summary of execution result>
+- Requirement satisfaction: ○ / × / partial (with reason) for each item
+- Ambiguities: spots in the target prompt where you got stuck or wording you struggled to interpret (bullets)
+- Discretionary completions: spots not specified in the instructions where you filled in based on your own judgement (bullets)
+- Retries: how many times you redid the same judgement, and why
+```
+
+The caller extracts the self-report portion from the report and pulls `tool_uses` / `duration_ms` from the Agent tool's usage metadata to fill in the evaluation axes table.
+
+## Environment constraints
+
+In environments where dispatching a fresh subagent is not possible (already running as a subagent, the Task tool is disabled, etc.), this skill **does not apply**.
+- Alternative 1: ask the user of the parent session to launch a separate Claude Code session and run it
+- Alternative 2: skip the evaluation and explicitly report to the user "empirical evaluation skipped: dispatch unavailable"
+- **NG**: substituting self-rereading (bias creeps in, so the evaluation result cannot be trusted)
+
+**Structural review mode**: when you only want to check **textual consistency and clarity** of a skill / prompt rather than empirical evaluation, switch into structural review mode explicitly. State "this round is structural review mode: textual consistency check, not execution" in the request prompt to the subagent. This way the subagent does not fall into the skip behaviour from the environment-constraints section and can return a static review. Structural review supplements, not substitutes, empirical evaluation (it cannot count toward consecutive-clear judgement).
+
+## Stopping criteria
+
+- **Convergence (stop)**: two consecutive rounds satisfying **all** of:
+  - New ambiguities: 0
+  - Accuracy improvement vs. previous: +3 points or less (saturation, like 5% → 8%)
+  - Step-count change vs. previous: within ±10%
+  - Duration change vs. previous: within ±15%
+  - **Overfitting check**: at convergence, add one previously-unused hold-out scenario and evaluate. If accuracy drops 15 points or more from the recent average, that is overfitting. Go back to baseline scenario design and add edge cases.
+- **Divergence (suspect the design)**: if 3+ iterations fail to reduce new ambiguities → the prompt's design direction itself may be wrong. Stop patching and rewrite the structure.
+- **Resource cutoff**: when importance and improvement cost no longer balance, stop (the call to ship at 80%).
+
+## Presentation format
+
+Record and present each iteration to the user in this form:
+
+```
+## Iteration N
+
+### Changes (diff vs. previous)
+- <one-line description of the edit>
+
+### Results (per scenario)
+| Scenario | Success/Failure | Accuracy | steps | duration | retries |
+|---|---|---|---|---|---|
+| A | ○ | 90% | 4 | 20s | 0 |
+| B | × | 60% | 9 | 41s | 2 |
+
+### Ambiguities (newly observed this round)
+- <Scenario B>: [critical] item N was × — <one-line reason for the drop>   # always include on failure
+- <Scenario B>: <other observation, one line>
+- <Scenario A>: (none new)
+
+### Discretionary completions (newly observed this round)
+- <Scenario B>: <what was filled in>
+
+### Next edit
+- <minimal edit, one line>
+
+(Convergence: X consecutive clears / Y rounds remaining to stop)
+```
+
+## Red flags (watch for rationalization)
+
+| The rationalization that surfaces | The reality |
+|---|---|
+| "Rereading it myself produces the same effect" | You cannot "objectively view" text you just wrote. Always dispatch a fresh subagent. |
+| "One scenario is enough" | One scenario overfits. Two minimum, three preferred. |
+| "Zero ambiguities once is the end" | It can be coincidence. Confirm with two consecutive rounds. |
+| "Let's crush multiple ambiguities at once" | You lose track of what worked. One theme per iteration. |
+| "Let's split related minor edits one-per-iteration too" | The opposite trap. "One theme" is a semantic unit. 2-3 related minor edits in a single iter is fine. Splitting too far makes iter count explode. |
+| "Metrics look good, ignore the qualitative feedback" | Time reduction can also signal thinning. Qualitative is primary. |
+| "It is faster to rewrite from scratch" | If 3+ rounds fail to reduce ambiguities, that is the right call. Before that point it is escapism. |
+| "Let's reuse the same subagent" | It has learned the previous improvement. Dispatch fresh every time. |
+
+## Common failures
+
+- **Scenario too easy / too hard**: neither produces signal. One median plus one edge from real usage situations.
+- **Looking only at metrics**: chasing only time reduction strips out important explanation and makes the prompt brittle.
+- **Too many changes per iteration**: you lose track of "which of those edits worked". One edit, one iteration.
+- **Tuning scenarios to match the edits**: making scenarios easier so ambiguities appear to be resolved → backwards.
+
+## Related
+
+- `superpowers:writing-skills` — TDD approach for skill creation. Essentially the same as this skill's "subagent baseline → edit → re-run" loop.
+- `retrospective-codify` — codifying lessons after a task. Use this skill during prompt development; use `retrospective-codify` after a task ends.
+- `superpowers:dispatching-parallel-agents` — etiquette for running multiple scenarios in parallel.

--- a/config/agents/skills/empirical-prompt-tuning/SKILL.md
+++ b/config/agents/skills/empirical-prompt-tuning/SKILL.md
@@ -29,15 +29,15 @@ When not to use:
 1. **Baseline preparation**: fix the target prompt and prepare the following two:
    - **Evaluation scenarios**, 2 to 3 (1 median + 1 to 2 edge). Tasks that could realistically occur, simulating situations where the target prompt is actually applied.
    - **Requirements checklist** (for accuracy calculation). For each scenario, list 3 to 7 items the deliverable must satisfy. Accuracy % = items satisfied / total items. Fix this in advance (do not move it later).
-2. **Bias-free read**: have a "blank" executor read the instructions. **Dispatch a fresh subagent** via the Task tool. Do not settle for self-rereading (it is structurally impossible to view text you just wrote objectively). When running multiple scenarios in parallel, place multiple Agent calls in a single message. For environments where dispatch is unavailable, see the "Environment constraints" section.
+2. **Bias-free read**: have a "blank" executor read the instructions. **Dispatch a fresh subagent** via the Agent tool. Do not settle for self-rereading (it is structurally impossible to view text you just wrote objectively). When running multiple scenarios in parallel, place multiple Agent tool calls in a single message. For environments where dispatch is unavailable, see the "Environment constraints" section.
 3. **Execution**: hand the subagent a prompt that follows the **subagent invocation contract** below and have it run the scenario. The executor produces an implementation or output, then returns a self-report at the end.
 4. **Two-sided evaluation**: from the returned result, record the following.
    - **Executor self-report** (extracted from the body of the subagent's report): ambiguities / discretionary completions / spots where template application got stuck
    - **Instruction-side metrics** (judgement rules are defined in this section as the single source of truth; other places reference back here):
      - Success/failure: success (○) only when **all** items tagged `[critical]` are ○. If even one is × or partial, it is failure (×). Labels are binary, ○ / × only.
      - Accuracy (achievement rate of the requirements checklist, as %. ○ = full mark, × = 0, partial = 0.5; sum and divide by total items)
-     - Step count (use the `tool_uses` value in the usage metadata returned by the Task tool as is. Include Read / Grep — do not exclude them.)
-     - Duration (`duration_ms` from the Task tool usage metadata)
+     - Step count (use the `tool_uses` value in the usage metadata returned by the Agent tool as is. Include Read / Grep — do not exclude them.)
+     - Duration (`duration_ms` from the Agent tool usage metadata)
      - Retry count (how many times the subagent redid the same judgement. Extracted from the subagent's self-report; not measurable on the instruction side.)
      - **On failure, add a one-liner under "ambiguities" in the presentation format saying which `[critical]` item dropped** (for cause tracking)
    - The requirements checklist must contain **at least one** `[critical]`-tagged item (with zero, the success judgement becomes vacuous). Do not add or remove `[critical]` after the fact.
@@ -76,6 +76,9 @@ The prompt handed to the executor takes the following structure. This is the inp
 ```
 You are an executor reading <target prompt name> with a blank slate.
 
+## Mode
+empirical  # change to "structural" for textual consistency check only (see "Environment constraints: Structural review mode")
+
 ## Target prompt
 <paste the full body of the target prompt, or specify the path to Read>
 
@@ -87,7 +90,6 @@ You are an executor reading <target prompt name> with a blank slate.
 2. <regular item>
 3. <regular item>
 ...
-(Judgement rules are defined as the single source of truth in "Workflow 4. Two-sided evaluation / Instruction-side metrics". At least one [critical] is required.)
 
 ## Task
 1. Follow the target prompt to execute the scenario and produce the deliverable.
@@ -101,11 +103,13 @@ You are an executor reading <target prompt name> with a blank slate.
 - Retries: how many times you redid the same judgement, and why
 ```
 
+> Judgement rules are defined as the single source of truth in "Workflow 4. Two-sided evaluation / Instruction-side metrics". At least one [critical] is required.
+
 The caller extracts the self-report portion from the report and pulls `tool_uses` / `duration_ms` from the Agent tool's usage metadata to fill in the evaluation axes table.
 
 ## Environment constraints
 
-In environments where dispatching a fresh subagent is not possible (already running as a subagent, the Task tool is disabled, etc.), this skill **does not apply**.
+In environments where dispatching a fresh subagent is not possible (already running as a subagent, the Agent tool is disabled, etc.), this skill **does not apply**.
 - Alternative 1: ask the user of the parent session to launch a separate Claude Code session and run it
 - Alternative 2: skip the evaluation and explicitly report to the user "empirical evaluation skipped: dispatch unavailable"
 - **NG**: substituting self-rereading (bias creeps in, so the evaluation result cannot be trusted)
@@ -116,10 +120,10 @@ In environments where dispatching a fresh subagent is not possible (already runn
 
 - **Convergence (stop)**: two consecutive rounds satisfying **all** of:
   - New ambiguities: 0
-  - Accuracy improvement vs. previous: +3 points or less (saturation, like 5% → 8%)
-  - Step-count change vs. previous: within ±10%
+  - Accuracy improvement vs. previous: +3 percentage points or less (saturation, like 5% → 8%)
+  - Step-count change vs. previous: within ±10% (or ±1 step, whichever is larger)
   - Duration change vs. previous: within ±15%
-  - **Overfitting check**: at convergence, add one previously-unused hold-out scenario and evaluate. If accuracy drops 15 points or more from the recent average, that is overfitting. Go back to baseline scenario design and add edge cases.
+  - **Overfitting check**: at convergence, add one previously-unused hold-out scenario and evaluate. If accuracy drops 15 percentage points or more from the recent average, that is overfitting. Go back to baseline scenario design and add edge cases.
 - **Divergence (suspect the design)**: if 3+ iterations fail to reduce new ambiguities → the prompt's design direction itself may be wrong. Stop patching and rewrite the structure.
 - **Resource cutoff**: when importance and improvement cost no longer balance, stop (the call to ship at 80%).
 

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "model": "opusplan",
   "cleanupPeriodDays": 30,
   "env": {
     "BASH_DEFAULT_TIMEOUT_MS": "300000",
@@ -7,11 +8,42 @@
     "CLAUDE_CODE_DISABLE_LOCATION": "1",
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_SUBPROCESS_ENV_SCRUB": "1",
     "DISABLE_AUTOUPDATER": "1",
     "DISABLE_BUG_COMMAND": "1",
     "DISABLE_ERROR_REPORTING": "1"
   },
   "includeCoAuthoredBy": false,
+  "sandbox": {
+    "enabled": false,
+    "failIfUnavailable": true,
+    "autoAllowBashIfSandboxed": true,
+    "allowUnsandboxedCommands": false,
+    "network": {
+      "allowedDomains": [
+        "github.com",
+        "*.github.com",
+        "*.githubusercontent.com",
+        "api.anthropic.com"
+      ],
+      "deniedDomains": [],
+      "allowManagedDomainsOnly": false,
+      "allowUnixSockets": [],
+      "allowAllUnixSockets": false,
+      "allowLocalBinding": false,
+      "allowMachLookup": []
+    },
+    "filesystem": {
+      "denyWrite": [],
+      "allowWrite": [],
+      "denyRead": [],
+      "allowRead": [],
+      "allowManagedReadPathsOnly": false
+    },
+    "enableWeakerNestedSandbox": false,
+    "enableWeakerNetworkIsolation": false,
+    "excludedCommands": []
+  },
   "permissions": {
     "allow": [
       "Bash(awk:*)",
@@ -169,13 +201,11 @@
       "Bash(git reset:*)",
       "Bash(git restore:*)",
       "Bash(git revert:*)",
-      "Bash(git rm:*)",
       "Bash(git stash:*)",
       "Bash(git switch:*)",
       "Bash(git tag:*)",
       "Bash(git worktree:*)",
       "Bash(op:*)",
-      "Bash(rm:*)",
       "Bash(security:*)",
       "Bash(sudo:*)",
       "Read(.env.*)",
@@ -189,7 +219,8 @@
       "Write(/etc/*)",
       "Edit(~/.ssh/*)",
       "Edit(/etc/*)"
-    ]
+    ],
+    "defaultMode": "default"
   },
   "hooks": {
     "PreToolUse": [
@@ -225,5 +256,12 @@
         ]
       }
     ]
-  }
+  },
+  "language": "japanese",
+  "tui": "fullscreen",
+  "voice": {
+    "enabled": false,
+    "mode": "hold"
+  },
+  "voiceEnabled": false
 }

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -1,7 +1,7 @@
 # See: https://developers.openai.com/codex/config-reference
 
 # Model
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "medium"
 model_reasoning_summary = "auto"
 model_verbosity = "medium"

--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -39,7 +39,7 @@
   "agent": {
     "plan": {
       "description": "Use only for non-trivial changes: unfamiliar subsystem, multi-file edits, unclear design, or risky behavior changes. Read code, identify existing patterns/utilities, and return a concise implementation plan. Do not edit files.",
-      "mode": "subagent",
+      "mode": "primary",
       "steps": 10,
       "temperature": 0.1,
       "permission": {

--- a/packages/codex-bin/default.nix
+++ b/packages/codex-bin/default.nix
@@ -7,11 +7,11 @@
   stdenvNoCC,
 }:
 let
-  version = "0.124.0";
+  version = "0.128.0";
   asset = "codex-aarch64-apple-darwin";
   src = fetchurl {
     url = "https://github.com/openai/codex/releases/download/rust-v${version}/${asset}.tar.gz";
-    hash = "sha256-ceh0SUR5HKi+IrmlGx8RFK+bBdbc0pkW5T85YevlKc4=";
+    hash = "sha256-8GggLoqJjCQMjAaEAbzNMLp7VvYfX/zRSD1UXUeq89U=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/gemini-cli-bin/default.nix
+++ b/packages/gemini-cli-bin/default.nix
@@ -8,10 +8,10 @@
   nodejs_22,
 }:
 let
-  version = "0.39.0";
+  version = "0.40.1";
   src = fetchurl {
     url = "https://registry.npmjs.org/@google/gemini-cli/-/gemini-cli-${version}.tgz";
-    hash = "sha256-iwCTMl/Woxb6Jzsqe5yY/w1xSwVgrh/Ug2OwA8mT0Mg=";
+    hash = "sha256-iTIFEnwHLTuqL7pBmigIG5/Vy3fHRYgxOd2ePiwaKy0=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/opencode-bin/default.nix
+++ b/packages/opencode-bin/default.nix
@@ -9,11 +9,11 @@
   unzip,
 }:
 let
-  version = "1.14.22";
+  version = "1.14.33";
   asset = "opencode-darwin-arm64";
   src = fetchurl {
     url = "https://github.com/sst/opencode/releases/download/v${version}/${asset}.zip";
-    hash = "sha256-zeqDvk2eEvD7SyFosSLwGj0CQ1k8r07IEEHF5tcX+Po=";
+    hash = "sha256-rpFCEVyhmYlBzkHuN55QLBOntIYcgP1cGnBHel+F26M=";
   };
 in
 stdenvNoCC.mkDerivation {


### PR DESCRIPTION


## Why
There was no codified method for iterating on agent-facing instructions; the prompt's author cannot judge its clarity from the inside, so revisions tended to plateau early and rely on intuition. Separately, agent CLIs and Claude Code settings had drifted from upstream — `Bash(rm:*)` / `Bash(git rm:*)` remained on the allowlist, and recent Claude Code options (subprocess env scrub, sandbox schema, `defaultMode`) were undeclared.

## What
- The new skill formalizes a "blank executor + two-sided evaluation" loop: dispatch a fresh subagent to run the prompt, score against a checklist with at least one `[critical]` item, and stop only when ambiguities and metric gains both flatline. Chosen over self-review (structurally biased — text you just wrote cannot be read objectively) and over LLM-as-judge against rubrics (rewards plausibility, not behavior).
- Permission tightening removed `rm` / `git rm` from the allowlist rather than gating them via path glob. Path-glob deny lists drift over time; per-call confirmation is acceptable because these calls are rare.
- The Claude Code in-process `sandbox` block is added as scaffolding with `enabled: false`. The macOS Seatbelt wrapper (`claude-code-sandboxed`) remains the primary defense; Claude Code's in-process `denyWrite/allowWrite` is known to apply only to `Bash` (asymmetric to `Write`/`Edit`), so enabling it now would imply a stronger guarantee than it provides. Keeping the schema declared makes future toggling a one-line change.
- CLI bumps (codex, gemini-cli, opencode) are routine catch-up. opencode's `agent.plan.mode` flipped to `primary` so plan mode runs in the foreground — plans need iteration with the user, which subagent-mode obstructs.

## References
N/A
