### PR TITLE
Add global gitleaks pre-commit hook via core.hooksPath

### DIFF
--- a/modules/shared/git.nix
+++ b/modules/shared/git.nix
@@ -1,7 +1,20 @@
 # see: https://github.com/nix-community/home-manager/blob/master/modules/programs/git.nix
-{ pkgs, ... }:
+{ config, pkgs, ... }:
 
 let
+  preCommitHook = pkgs.writeShellScript "global-pre-commit" ''
+    set -eu
+
+    ${pkgs.gitleaks}/bin/gitleaks protect --staged --redact --verbose
+
+    # Delegate to the repository's own pre-commit hook so per-repo setups keep working.
+    git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
+    repo_hook="$git_dir/hooks/pre-commit"
+    if [ -x "$repo_hook" ]; then
+      exec "$repo_hook"
+    fi
+  '';
+
   git-clean = pkgs.writeShellScriptBin "git-clean" ''
     #!/bin/sh
 
@@ -35,8 +48,11 @@ in
   home.packages = with pkgs; [
     gh
     ghq
+    gitleaks
     git-clean
   ];
+
+  xdg.configFile."git/hooks/pre-commit".source = preCommitHook;
 
   programs.git = {
     enable = true;
@@ -45,7 +61,10 @@ in
         name = "usabarashi";
         email = "19676305+usabarashi@users.noreply.github.com";
       };
-      core.autocrlf = "input";
+      core = {
+        autocrlf = "input";
+        hooksPath = "${config.xdg.configHome}/git/hooks";
+      };
       credential.helper = "osxkeychain";
     };
     ignores = [
@@ -54,6 +73,7 @@ in
       ".DS_Store"
       ".direnv"
       ".env"
+      ".envrc"
       ".claude/settings.local.json"
       ".serena"
     ];

--- a/modules/shared/git.nix
+++ b/modules/shared/git.nix
@@ -5,14 +5,16 @@ let
   preCommitHook = pkgs.writeShellScript "global-pre-commit" ''
     set -eu
 
-    ${pkgs.gitleaks}/bin/gitleaks protect --staged --redact --verbose
-
-    # Delegate to the repository's own pre-commit hook so per-repo setups keep working.
-    git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
-    repo_hook="$git_dir/hooks/pre-commit"
-    if [ -x "$repo_hook" ]; then
-      exec "$repo_hook"
+    # Run the repository's own pre-commit hook first; it may rewrite and re-stage
+    # files (formatters, codegen), so we must scan the resulting index, not the
+    # one the user originally staged. --git-path resolves to the common git dir
+    # (so worktrees are handled) and is not affected by core.hooksPath.
+    repo_hook=$(git rev-parse --git-path hooks/pre-commit 2>/dev/null || true)
+    if [ -n "$repo_hook" ] && [ -x "$repo_hook" ]; then
+      "$repo_hook" "$@"
     fi
+
+    exec ${pkgs.gitleaks}/bin/gitleaks protect --staged --redact --verbose
   '';
 
   git-clean = pkgs.writeShellScriptBin "git-clean" ''


### PR DESCRIPTION


## Why
Secret scanning previously had to be wired per-repository, so any repo without that wiring could commit credentials without ever invoking gitleaks. Enforcing it as a user-level setting closes that gap uniformly without each repository having to opt in.

## What
- Chose global `core.hooksPath` pointing at a Nix-managed hooks directory: it applies retroactively to every existing repository, stays reproducible through home-manager, and replaces ad-hoc per-repo wiring with a single source of truth.
- Rejected `init.templateDir`: it only seeds freshly initialised or cloned repositories and would leave existing checkouts unscanned until re-initialised.
- Rejected duplicating `.pre-commit-config.yaml` across repos: silent omissions are exactly the failure mode this PR removes.
- The hook delegates to `.git/hooks/pre-commit` when one exists, locating it via `git rev-parse --git-dir` (which is unaffected by `core.hooksPath`, avoiding self-recursion). This keeps repo-local hook frameworks working alongside the global scanner.
- Added `.envrc` to the user-level gitignore because direnv files are developer-local and should not be staged by default in repositories that do not already track them.

## References
N/A
