### PR TITLE
Fix pre-commit hook recursion under core.hooksPath

### DIFF
--- a/modules/shared/git.nix
+++ b/modules/shared/git.nix
@@ -5,13 +5,13 @@ let
   preCommitHook = pkgs.writeShellScript "global-pre-commit" ''
     set -eu
 
-    # Run the repository's own pre-commit hook first; it may rewrite and re-stage
-    # files (formatters, codegen), so we must scan the resulting index, not the
-    # one the user originally staged. --git-path resolves to the common git dir
-    # (so worktrees are handled) and is not affected by core.hooksPath.
-    repo_hook=$(git rev-parse --git-path hooks/pre-commit 2>/dev/null || true)
-    if [ -n "$repo_hook" ] && [ -x "$repo_hook" ]; then
-      "$repo_hook" "$@"
+    # Run the repository's own pre-commit hook first if present. We must use
+    # --git-common-dir (not --git-path hooks/pre-commit) because the latter
+    # honors core.hooksPath and would resolve to this script itself, causing
+    # infinite recursion / fork bomb.
+    git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
+    if [ -n "$git_common_dir" ] && [ -x "$git_common_dir/hooks/pre-commit" ]; then
+      "$git_common_dir/hooks/pre-commit" "$@"
     fi
 
     exec ${pkgs.gitleaks}/bin/gitleaks protect --staged --redact --verbose


### PR DESCRIPTION


## Why
The global `pre-commit` hook installed via `core.hooksPath` was self-recursing on every `git commit`, exhausting the user-process limit until `fork: Resource temporarily unavailable` surfaced. The recursion forked thousands of `global-pre-commit` processes per commit (~4k observed), making commits take tens of seconds and intermittently fail across every repository on the host.

## What
The bug was a wrong assumption baked into the previous comment: `git rev-parse --git-path` *does* honor `core.hooksPath`, so `--git-path hooks/pre-commit` resolved to this script itself rather than the repository's `.git/hooks/pre-commit`. The script then re-exec'd itself before reaching `gitleaks`, and each child repeated the same expansion.

- Chosen fix: resolve the repository hook via `git rev-parse --git-common-dir` and execute `$dir/hooks/pre-commit` directly. `--git-common-dir` is unaffected by `core.hooksPath`, still handles worktrees correctly (it returns the shared git dir), and preserves the original intent of running repo-local hooks before the global gitleaks scan.
- Rejected alternative: detecting self-invocation via `realpath "$0"` vs `realpath "$repo_hook"`. It works but adds a `coreutils` dependency and leaves the misleading `--git-path` call in place, so the simpler structural fix was preferred.

## References
- #90
