### PR TITLE
Add commit signing and github SSH auth via Secretive

### DIFF
--- a/modules/shared/git.nix
+++ b/modules/shared/git.nix
@@ -1,7 +1,19 @@
 # see: https://github.com/nix-community/home-manager/blob/master/modules/programs/git.nix
-{ config, pkgs, ... }:
+{
+  config,
+  pkgs,
+  ...
+}:
 
 let
+  userName = "usabarashi";
+  userEmail = "19676305+usabarashi@users.noreply.github.com";
+
+  # Paths only; the file contents are populated manually because the keys are
+  # random data tied to a specific Secure Enclave and not reproducible by Nix.
+  signingKeyPath = "${config.xdg.configHome}/git/signing-key.pub";
+  allowedSignersPath = "${config.xdg.configHome}/git/allowed_signers";
+
   preCommitHook = pkgs.writeShellScript "global-pre-commit" ''
     set -eu
 
@@ -60,14 +72,31 @@ in
     enable = true;
     settings = {
       user = {
-        name = "usabarashi";
-        email = "19676305+usabarashi@users.noreply.github.com";
+        name = userName;
+        email = userEmail;
+        signingKey = signingKeyPath;
       };
       core = {
         autocrlf = "input";
         hooksPath = "${config.xdg.configHome}/git/hooks";
       };
       credential.helper = "osxkeychain";
+
+      commit.gpgsign = true;
+      tag.gpgsign = true;
+      push.gpgSign = "if-asked";
+
+      gpg = {
+        format = "ssh";
+        ssh.allowedSignersFile = allowedSignersPath;
+      };
+
+      transfer.fsckObjects = true;
+      fetch.fsckObjects = true;
+      receive.fsckObjects = true;
+
+      init.defaultBranch = "main";
+      pull.ff = "only";
     };
     ignores = [
       "*~"

--- a/modules/shared/git.nix
+++ b/modules/shared/git.nix
@@ -82,9 +82,8 @@ in
       };
       credential.helper = "osxkeychain";
 
-      commit.gpgsign = true;
-      tag.gpgsign = true;
-      push.gpgSign = "if-asked";
+      commit.gpgSign = true;
+      tag.gpgSign = true;
 
       gpg = {
         format = "ssh";

--- a/modules/shared/ssh.nix
+++ b/modules/shared/ssh.nix
@@ -1,10 +1,25 @@
 # see: https://github.com/nix-community/home-manager/blob/master/modules/programs/ssh.nix
-_:
+{
+  config,
+  pkgs,
+  ...
+}:
 
 let
   extraConfigPath = "~/.ssh/extra_config";
+  secretiveSocket = "${config.home.homeDirectory}/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh";
+
+  # Path only; the file contents are populated manually because the key is
+  # random data tied to a specific Secure Enclave and not reproducible by Nix.
+  githubAuthKeyPath = "${config.home.homeDirectory}/.ssh/github.pub";
 in
 {
+  home.packages = [ pkgs.secretive ];
+
+  home.sessionVariables = {
+    SSH_AUTH_SOCK = secretiveSocket;
+  };
+
   programs.ssh = {
     enable = true;
     enableDefaultConfig = false;
@@ -18,14 +33,15 @@ in
         # Default SSH configuration
         serverAliveInterval = 60;
         serverAliveCountMax = 3;
+        extraOptions = {
+          IdentityAgent = secretiveSocket;
+        };
       };
 
       "github.com" = {
-        identityFile = "~/.ssh/github_rsa";
+        identityFile = githubAuthKeyPath;
         identitiesOnly = true;
-        user = "usabarashi";
       };
     };
-
   };
 }

--- a/modules/shared/ssh.nix
+++ b/modules/shared/ssh.nix
@@ -41,6 +41,7 @@ in
       "github.com" = {
         identityFile = githubAuthKeyPath;
         identitiesOnly = true;
+        user = "git";
       };
     };
   };


### PR DESCRIPTION


## Why
Commits previously had no cryptographic signature, so authorship was self-asserted metadata that any local process (including AI coding agents) could fake without user interaction. GitHub authentication relied on a 2021-era RSA 2048 key kept as a plaintext file on disk, with no per-use confirmation. The combination meant a compromised user-level process could push as the user without any human-in-the-loop gate.

## What
- Adopted Secretive as the SSH agent so the private key lives in the Secure Enclave and every signing/auth use requires biometric or password confirmation. 1Password was rejected because it requires an active subscription; plain ssh-agent + Keychain was rejected because once unlocked it signs silently for the rest of the session; YubiKey was rejected because it adds hardware cost and a single point of physical failure.
- Used ECDSA P-256 because it is the only algorithm the Apple Secure Enclave implements natively. Ed25519 would have been preferred for cleaner nonce handling, but is unavailable in this hardware path.
- Public-key file contents are user-managed outside Nix: the keys are random data bound to a specific Secure Enclave and cannot be reproduced declaratively. Nix only declares the paths, mirroring the existing `~/.ssh/extra_config` include pattern. `signingKey` and `allowedSignersFile` for git, plus `IdentityFile` for github SSH, all point at these manually-placed files.
- Hardened git defaults orthogonal to signing: `transfer/fetch/receive.fsckObjects` for object integrity, `pull.ff = only` to keep merge graph signed, `init.defaultBranch = main` for hygiene.
- Retired `~/.ssh/github_rsa` (RSA 2048) — replaced by an ECDSA P-256 keypair held inside Secretive and registered on GitHub.

## References
N/A
