### PR TITLE
Add Takumi Guard npm proxy configuration

### DIFF
--- a/config/node/npmrc
+++ b/config/node/npmrc
@@ -2,4 +2,6 @@
 # Anonymous-mode: no token required for the package-blocking feature.
 # Identity tracking and breach notifications are not provided in this mode.
 registry=https://npm.flatt.tech/
+# Client-side install cooldown in days, enforced by npm v11.10.0+.
+# pnpm/yarn use different keys (minimumReleaseAge) and ignore this harmlessly.
 min-release-age=7

--- a/config/node/npmrc
+++ b/config/node/npmrc
@@ -1,0 +1,5 @@
+# Takumi Guard registry proxy (https://flatt.tech/takumi/features/guard)
+# Anonymous-mode: no token required for the package-blocking feature.
+# Identity tracking and breach notifications are not provided in this mode.
+registry=https://npm.flatt.tech/
+min-release-age=7

--- a/home/private/default.nix
+++ b/home/private/default.nix
@@ -34,6 +34,7 @@
     ../../modules/shared/git.nix
     ../../modules/shared/llm.nix
     ../../modules/shared/neovim.nix
+    ../../modules/shared/node.nix
     ../../modules/shared/ssh.nix
     ../../modules/shared/terminal.nix
     ../../modules/shared/terraform.nix

--- a/home/work/default.nix
+++ b/home/work/default.nix
@@ -30,6 +30,7 @@
     ../../modules/shared/gcloud.nix
     ../../modules/shared/git.nix
     ../../modules/shared/neovim.nix
+    ../../modules/shared/node.nix
     ../../modules/shared/ssh.nix
     ../../modules/shared/terminal.nix
     ../../modules/shared/terraform.nix

--- a/modules/shared/node.nix
+++ b/modules/shared/node.nix
@@ -1,0 +1,15 @@
+{
+  config,
+  repoPath,
+  ...
+}:
+
+{
+  # npm registry routed through Takumi Guard's malicious-package blocking
+  # proxy (https://flatt.tech/takumi/features/guard). Anonymous mode --
+  # no token required. Applies to npm/pnpm/yarn/npx.
+  home.file.".npmrc" = {
+    source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/node/npmrc";
+    force = true;
+  };
+}


### PR DESCRIPTION


## Why
A recent npm supply-chain worm ("mini Shai Hulud 2nd") propagated malicious packages through compromised releases, and ad-hoc `npm`/`npx` invocations (including MCP server launches) had no protection against pulling a poisoned package. No user-level guard routed installs through any malicious-package screening.

## What
Routes npm installs through Takumi Guard's registry proxy, which screens packages against a threat database before download. Chose anonymous mode (registry URL only) over the token-based mode because the blocking feature works without registration, and the token only adds identity tracking / breach notifications that are not worth the secret-management overhead for a personal setup. The npmrc lives as a plain file under `config/` and is symlinked via `mkOutOfStoreSymlink` so it can be edited without re-running `nix run`, consistent with the existing `config/terraform` pattern. Also pins `min-release-age=7` as defense-in-depth against not-yet-flagged packages. Scoped to npm only for now; PyPI can follow the same pattern later.

## References
N/A
