### PR TITLE
Enable PAM reattach for sudo Touch ID authentication

### DIFF
--- a/hosts/private/default.nix
+++ b/hosts/private/default.nix
@@ -57,7 +57,10 @@
   };
 
   programs.zsh.enable = true;
-  security.pam.services.sudo_local.touchIdAuth = true;
+  security.pam.services.sudo_local = {
+    touchIdAuth = true;
+    reattach = true;
+  };
   time.timeZone = "Asia/Tokyo";
 
   # BlackHole 2ch Audio Driver

--- a/hosts/work/default.nix
+++ b/hosts/work/default.nix
@@ -57,6 +57,9 @@
   };
 
   programs.zsh.enable = true;
-  security.pam.services.sudo_local.touchIdAuth = true;
+  security.pam.services.sudo_local = {
+    touchIdAuth = true;
+    reattach = true;
+  };
   time.timeZone = "Asia/Tokyo";
 }


### PR DESCRIPTION


## Why
Touch ID for `sudo` (`touchIdAuth = true`) does not work inside tmux or
screen sessions: the server process is detached from the GUI login
(Aqua) namespace, so `pam_tid.so` cannot present a Touch ID prompt and
silently falls back to password entry.

## What
Added `reattach = true` to `security.pam.services.sudo_local` on both the
private and work hosts. This inserts `pam_reattach.so` into the sudo PAM
stack, which reattaches the authenticating process to the user's GUI
session namespace so `pam_tid.so` can prompt for Touch ID even from
within tmux. The setting is applied to both hosts to keep sudo
authentication behavior consistent across environments.

## References
N/A
