### PR TITLE
Add grill-me skill imported from mattpocock/skills

### DIFF
--- a/config/agents/skills/grill-me/LICENSE
+++ b/config/agents/skills/grill-me/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/config/agents/skills/grill-me/README.md
+++ b/config/agents/skills/grill-me/README.md
@@ -3,5 +3,5 @@
 Imported from [mattpocock/skills](https://github.com/mattpocock/skills).
 
 - Upstream source: [`skills/productivity/grill-me/SKILL.md`](https://github.com/mattpocock/skills/blob/62f43a18177be6ec82da242e59ffbc490a4c22ea/skills/productivity/grill-me/SKILL.md)
-- Status: verbatim copy, no local modifications
+- Status: `SKILL.md` is a verbatim copy of the pinned upstream commit; `LICENSE` is relocated from upstream root; this `README.md` is local
 - License: MIT (see [`LICENSE`](./LICENSE)) -- Copyright (c) 2026 Matt Pocock

--- a/config/agents/skills/grill-me/README.md
+++ b/config/agents/skills/grill-me/README.md
@@ -1,0 +1,7 @@
+# grill-me
+
+Imported from [mattpocock/skills](https://github.com/mattpocock/skills).
+
+- Upstream source: [`skills/productivity/grill-me/SKILL.md`](https://github.com/mattpocock/skills/blob/62f43a18177be6ec82da242e59ffbc490a4c22ea/skills/productivity/grill-me/SKILL.md)
+- Status: verbatim copy, no local modifications
+- License: MIT (see [`LICENSE`](./LICENSE)) -- Copyright (c) 2026 Matt Pocock

--- a/config/agents/skills/grill-me/SKILL.md
+++ b/config/agents/skills/grill-me/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.


### PR DESCRIPTION


## Why
There was no in-repo workflow for interview-style plan stress-testing before implementation, so design decisions tended to be validated only mid-coding when reversal is expensive. Upstream `mattpocock/skills` already ships a focused skill (`grill-me`) for exactly this loop, so writing a bespoke variant would have been duplicated effort.

## What
- Adopted the upstream skill verbatim rather than authoring a local variant: keeps semantics aligned with the original and reduces future maintenance to a re-copy when upstream updates.
- Pinned the upstream source to a specific commit SHA in the README instead of just naming the repo, so the exact provenance is auditable even if upstream history is rewritten.
- Co-located `LICENSE` next to `SKILL.md` (not at repo root) because the MIT attribution applies only to this imported subtree; this keeps the rest of the repo's licensing scope untouched and makes the boundary obvious to readers.
- Placed under `config/agents/skills/grill-me/` alongside other agent skills so discovery and loading conventions are uniform.

## References
N/A
