### PR TITLE
Bump flake for curl/openssl CVE fixes and HM 26.05 migration

### DIFF
--- a/config/nix-extra/flake.nix.example
+++ b/config/nix-extra/flake.nix.example
@@ -34,7 +34,7 @@
         { pkgs, ... }:
         {
           home.packages = [
-            # some-tool.packages.${pkgs.system}.default
+            # some-tool.packages.${pkgs.stdenv.hostPlatform.system}.default
           ];
         };
     };

--- a/flake.lock
+++ b/flake.lock
@@ -98,11 +98,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778144356,
-        "narHash": "sha256-dGM+QCstz/DyLB68+JK5GWyMx4QSqmOJEVgZmy63d/g=",
+        "lastModified": 1779726696,
+        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e4419d3123b780d5f4c0bceeace450424387638c",
+        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777780666,
-        "narHash": "sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE=",
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "8c62fba0854ba15c8917aed18894dbccb48a3777",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {
@@ -133,11 +133,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778036283,
-        "narHash": "sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE=",
+        "lastModified": 1779694939,
+        "narHash": "sha256-Ly4j75O8ICaSQx3uxPnwk2x7PMF0XQvn5r0c3yBA7FI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
+        "rev": "f9d8b65950353691ab56561e7c73d2e1063d810b",
         "type": "github"
       },
       "original": {
@@ -251,11 +251,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1778234906,
-        "narHash": "sha256-GiiBEIt1R6Ke93XYx3sKyMO9l+J5zJ5kk5IVkAv0nvY=",
+        "lastModified": 1779822216,
+        "narHash": "sha256-znrkhZghqwdD269TZbl4pvWQadEL8aZiBsnykM/JL8U=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "ab98ea676253e7a4efee7bc9f9aa7caf51cc6c52",
+        "rev": "9b292a6c8b03c8306f117efeabb0ea7afdb0b3c0",
         "type": "github"
       },
       "original": {

--- a/home/private/default.nix
+++ b/home/private/default.nix
@@ -10,7 +10,8 @@
   home = {
     username = userName;
     inherit homeDirectory;
-    stateVersion = "25.11";
+    stateVersion = "26.05";
+    enableNixpkgsReleaseCheck = false;
   };
 
   targets.darwin.copyApps = {

--- a/home/work/default.nix
+++ b/home/work/default.nix
@@ -10,7 +10,8 @@
   home = {
     username = userName;
     inherit homeDirectory;
-    stateVersion = "25.11";
+    stateVersion = "26.05";
+    enableNixpkgsReleaseCheck = false;
   };
 
   targets.darwin.copyApps = {

--- a/lib/builders.nix
+++ b/lib/builders.nix
@@ -28,6 +28,7 @@
         }:
         {
           ids.gids.nixbld = 350; # Use fixed GID instead of runtime detection
+          nixpkgs.hostPlatform = system;
           nixpkgs.overlays = import ../lib/overlays.nix;
           nixpkgs.config.allowUnfree = true;
           users.users.${userName} = {
@@ -37,7 +38,6 @@
         };
     in
     nix-darwin.lib.darwinSystem {
-      inherit system;
       specialArgs = {
         inherit userName homeDirectory;
       };

--- a/lib/builders.nix
+++ b/lib/builders.nix
@@ -28,9 +28,11 @@
         }:
         {
           ids.gids.nixbld = 350; # Use fixed GID instead of runtime detection
-          nixpkgs.hostPlatform = system;
-          nixpkgs.overlays = import ../lib/overlays.nix;
-          nixpkgs.config.allowUnfree = true;
+          nixpkgs = {
+            hostPlatform = system;
+            overlays = import ../lib/overlays.nix;
+            config.allowUnfree = true;
+          };
           users.users.${userName} = {
             home = homeDirectory;
             shell = pkgs.zsh;

--- a/modules/shared/neovim.nix
+++ b/modules/shared/neovim.nix
@@ -9,6 +9,8 @@
     viAlias = true;
     vimAlias = true;
     defaultEditor = true;
+    withRuby = false;
+    withPython3 = false;
 
     extraConfig = ''
       " Set leader key to Space

--- a/modules/shared/ssh.nix
+++ b/modules/shared/ssh.nix
@@ -28,20 +28,17 @@ in
       extraConfigPath
     ];
 
-    matchBlocks = {
+    settings = {
       "*" = {
-        # Default SSH configuration
-        serverAliveInterval = 60;
-        serverAliveCountMax = 3;
-        extraOptions = {
-          IdentityAgent = secretiveSocket;
-        };
+        ServerAliveInterval = 60;
+        ServerAliveCountMax = 3;
+        IdentityAgent = secretiveSocket;
       };
 
       "github.com" = {
-        identityFile = githubAuthKeyPath;
-        identitiesOnly = true;
-        user = "git";
+        IdentityFile = githubAuthKeyPath;
+        IdentitiesOnly = true;
+        User = "git";
       };
     };
   };

--- a/modules/shared/vscode.nix
+++ b/modules/shared/vscode.nix
@@ -22,7 +22,7 @@ in
   home = {
     packages = with pkgs; [
       nil
-      nixfmt-rfc-style
+      nixfmt
     ];
 
     file = {


### PR DESCRIPTION


## Why
Security audit flagged CVE-2026-6429 / 7168 (curl 8.19.0 netrc credential leak via HTTP proxy redirect) and CVE-2026-31790 (OpenSSL 3.5.5 RSA KEM uninitialized memory leak) in the locked nixpkgs revision; both fixes are in newer upstream nixpkgs. Bumping nixpkgs also pulls home-manager and nix-darwin forward, which surfaces a wave of deprecation warnings from the HM 26.05 / nixpkgs 26.11 channels that need to be cleared in the same change.

## What
- Bundled the dependency bump and warning cleanup into one PR. Splitting would force PR2 to depend on PR1 since the warnings only appear after the bump, and the two are tightly coupled enough that separating them would add churn without clarifying review.
- Migrated SSH config to the new `programs.ssh.settings` API using upstream OpenSSH directive names. The previous `extraOptions.IdentityAgent` escape hatch is no longer needed because the new API accepts arbitrary directives directly.
- Bumped `home.stateVersion` from 25.11 to 26.05 after verifying that none of the other 26.05 state-version-gated default changes (zsh dotDir, yazi shellWrapperName, xdg.userDirs, programs.man on Darwin, firefox, hyprland, gtk4) touch this config. The explicit `programs.neovim.withRuby/withPython3 = false` is kept as documentation even though it now matches the new default.
- Switched nix-darwin invocation from the legacy `system` argument to the recommended `nixpkgs.hostPlatform` module attribute, which also silences the `pkgs.system` → `pkgs.stdenv.hostPlatform.system` rename warning surfaced by the bumped nixpkgs.
- Suppressed the HM/Nixpkgs release-version skew warning with `home.enableNixpkgsReleaseCheck = false`. HM master has not yet bumped its release marker to track nixpkgs 26.11; silencing is the upstream-recommended escape hatch for this transient state.

## References
N/A
