### PR TITLE
Bump agent CLI pins and migrate Gemini ui.inlineThinkingMode

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,21 +3,27 @@ project_name: "nix-config"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   java                julia               kotlin              lua                 markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
@@ -47,53 +53,17 @@ read_only: false
 
 # list of tool names to exclude.
 # This extends the existing exclusions (e.g. from the global configuration)
-#
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
 # This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -104,11 +74,14 @@ fixed_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -150,3 +123,19 @@ ignored_memory_patterns: []
 # Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
 # No documentation on options means no options are available.
 ls_specific_settings: {}
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -146,7 +146,5 @@
   ],
   "githubPullRequests.pullBranch": "never",
   "diffEditor.codeLens": true,
-  "lean4.alwaysAskBeforeInstallingLeanVersions": true,
-  "security.promptForLocalFileProtocolHandling": false,
-  "security.workspace.trust.untrustedFiles": "open"
+  "lean4.alwaysAskBeforeInstallingLeanVersions": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -146,5 +146,7 @@
   ],
   "githubPullRequests.pullBranch": "never",
   "diffEditor.codeLens": true,
-  "lean4.alwaysAskBeforeInstallingLeanVersions": true
+  "lean4.alwaysAskBeforeInstallingLeanVersions": true,
+  "security.promptForLocalFileProtocolHandling": false,
+  "security.workspace.trust.untrustedFiles": "open"
 }

--- a/config/gemini/settings.json
+++ b/config/gemini/settings.json
@@ -15,7 +15,7 @@
   "ui": {
     "theme": "Default",
     "showLineNumbers": true,
-    "thinking": "full"
+    "inlineThinkingMode": "full"
   },
   "ide": {
     "hasSeenNudge": true,

--- a/flake.lock
+++ b/flake.lock
@@ -251,11 +251,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1779822216,
-        "narHash": "sha256-znrkhZghqwdD269TZbl4pvWQadEL8aZiBsnykM/JL8U=",
+        "lastModified": 1779881517,
+        "narHash": "sha256-mgC2rUVlBRHP+OFMW8BiWNXq13eqWMjoLBt2jP9dJXU=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "9b292a6c8b03c8306f117efeabb0ea7afdb0b3c0",
+        "rev": "7bf30080f6aa8fc1f983e1d72bc91dd790f28d29",
         "type": "github"
       },
       "original": {

--- a/packages/claude-code-bin/default.nix
+++ b/packages/claude-code-bin/default.nix
@@ -7,10 +7,10 @@
   stdenvNoCC,
 }:
 let
-  version = "2.1.137";
+  version = "2.1.144";
   src = fetchurl {
     url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${version}/darwin-arm64/claude";
-    hash = "sha256-bZHOdBuKoSn9Q8L4RLOdzB/sjP136OWh7Q8Oe6VM/qk=";
+    hash = "sha256-mIa6pOxMRV+GEIRk8SFzIZPuduXfzrAxAF9Z8xJ2pd8=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/codex-bin/default.nix
+++ b/packages/codex-bin/default.nix
@@ -7,11 +7,11 @@
   stdenvNoCC,
 }:
 let
-  version = "0.130.0";
+  version = "0.134.0";
   asset = "codex-aarch64-apple-darwin";
   src = fetchurl {
     url = "https://github.com/openai/codex/releases/download/rust-v${version}/${asset}.tar.gz";
-    hash = "sha256-vFCkt/mgyMqZF5GJ5GWbYBEHgwdw4hVH3Awka85zNXc=";
+    hash = "sha256-eK1ILMrrDriYOzQPM6HyjIrTFbbV4xQMNMfhGcgmvBI=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/gemini-cli-bin/default.nix
+++ b/packages/gemini-cli-bin/default.nix
@@ -8,10 +8,10 @@
   nodejs_22,
 }:
 let
-  version = "0.41.2";
+  version = "0.44.0";
   src = fetchurl {
     url = "https://registry.npmjs.org/@google/gemini-cli/-/gemini-cli-${version}.tgz";
-    hash = "sha256-iA1FpPhnluwh2GMISpkyAlHJoqSWlBmpLzMTvVQkYBg=";
+    hash = "sha256-1e+nDMJe5L8G3zFpYhq497+D5XSB5gGNg3FkEj1KPIk=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/opencode-bin/default.nix
+++ b/packages/opencode-bin/default.nix
@@ -9,11 +9,11 @@
   unzip,
 }:
 let
-  version = "1.14.41";
+  version = "1.15.11";
   asset = "opencode-darwin-arm64";
   src = fetchurl {
     url = "https://github.com/sst/opencode/releases/download/v${version}/${asset}.zip";
-    hash = "sha256-eVYKWj8c+WU4s37HiuP5IybKU2p7taL26MHn6aK2/tI=";
+    hash = "sha256-+C8L2yhYNpccY2d90Y1wBduvRr/QTiI4OQW/hFP024w=";
   };
 in
 stdenvNoCC.mkDerivation {


### PR DESCRIPTION


## Why
The four AI-agent CLIs have shipped several releases since the last bump (#95), and Gemini's `ui.thinking` key — set during that previous cycle — has been outside the settings schema since at least v0.40 (canonical name is `ui.inlineThinkingMode`), so the value has been silently no-op. Bundling the version refresh with the schema-name fix realigns both before further Gemini settings get layered on the wrong key.

## What
- Pinned each tool to its current stable release; deliberately skipped Codex 0.135-alpha because the only strict-config breaking change in stable 0.134 is rejection of the legacy `[profiles]` table, which is not used here.
- Audited every upstream breaking change against the checked-in configs: Codex `web_search = "live"` remains valid (`WebSearchMode::Live` unchanged), as do `personality`, `[features].memories`, `[history]`, and the `[projects.*]` trust block. Gemini's Auto-mode consolidation is a CLI/UX-only change and does not touch settings.json. The only required edit was the Gemini key rename.
- Chose to rename rather than drop the Gemini key: `"full"` is a valid value of the new `off`/`full` enum and matches the prior intent, so this is the lowest-disruption migration.
- `.serena/project.yml` is a regen artifact of the bumped serena flake input — expanded language list and trimmed tool-overview comments, no policy or behavior change.
- Drive-by: two `security.*` toggles in `.vscode/settings.json` to suppress local-file-protocol and untrusted-files prompts; personal preference, not load-bearing for the bumps.

## References
N/A
