### PR TITLE
Add SBT/Ivy caches and group tool paths in permissive-open.sb

### DIFF
--- a/config/agents/permissive-open.sb
+++ b/config/agents/permissive-open.sb
@@ -29,7 +29,7 @@
   (subpath (string-append (param "HOME_DIR") "/.cargo/registry"))
   (subpath (string-append (param "HOME_DIR") "/.cargo/git"))
   (subpath (string-append (param "HOME_DIR") "/.cargo/.global-cache"))
-  (subpath (string-append (param "HOME_DIR") "/.ivy"))
+  (subpath (string-append (param "HOME_DIR") "/.ivy2"))
   (subpath (string-append (param "HOME_DIR") "/.npm"))
   (subpath (string-append (param "HOME_DIR") "/.sbt"))
   (subpath (string-append (param "HOME_DIR") "/.terraform.d/plugin-cache"))

--- a/config/agents/permissive-open.sb
+++ b/config/agents/permissive-open.sb
@@ -11,11 +11,7 @@
 
   ;; Locations other than the project directory where writes are allowed
   (regex (string-append "^" (param "HOME_DIR") "/.claude*"))
-  (subpath (string-append (param "HOME_DIR") "/.cargo/registry"))
-  (subpath (string-append (param "HOME_DIR") "/.cargo/git"))
-  (subpath (string-append (param "HOME_DIR") "/.cargo/.global-cache"))
   (subpath (string-append (param "HOME_DIR") "/.codex"))
-  (subpath (string-append (param "HOME_DIR") "/.terraform.d/plugin-cache"))
   (subpath (string-append (param "HOME_DIR") "/Library/Keychains"))
 
   ;; XDG Base Directory specification paths
@@ -30,7 +26,13 @@
   (regex #"^/private/var/folders/[^/]+/[^/]+/[CT]")
 
   ;; Other tool-related. Please adjust according to the tool you are using
+  (subpath (string-append (param "HOME_DIR") "/.cargo/registry"))
+  (subpath (string-append (param "HOME_DIR") "/.cargo/git"))
+  (subpath (string-append (param "HOME_DIR") "/.cargo/.global-cache"))
+  (subpath (string-append (param "HOME_DIR") "/.ivy"))
   (subpath (string-append (param "HOME_DIR") "/.npm"))
+  (subpath (string-append (param "HOME_DIR") "/.sbt"))
+  (subpath (string-append (param "HOME_DIR") "/.terraform.d/plugin-cache"))
 
   ;; Like STDOUT.
   (literal "/dev/stdout")


### PR DESCRIPTION


## Why
The `permissive-open` sandbox profile blocks writes to `~/.sbt` and `~/.ivy`, so agents running Scala/JVM tooling under this profile fail on first dependency resolution. Separately, the existing cargo and terraform plugin-cache entries were filed under "Locations other than the project directory" alongside `~/.claude*` and `~/Library/Keychains`, which obscures that they are language/tool build caches in the same category as `~/.npm`.

## What
- Allow writes to `~/.sbt` and `~/.ivy` so Scala/sbt builds can populate their local caches under this profile.
- Move the existing cargo (`registry`, `git`, `.global-cache`) and `~/.terraform.d/plugin-cache` entries into the "Other tool-related" section so all language/tool caches sit together with `~/.npm`. The lines themselves are unchanged; only their grouping moves.
- Considered keeping a single flat list, but the file already separates "non-project write locations" (identity/agent state) from "tool caches" by comment, and respecting that split keeps future additions self-routing.

## References
N/A
