### PR TITLE
Disable Codex CLI anonymous usage analytics

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -18,6 +18,10 @@ project_doc_fallback_filenames = ["CLAUDE.md", "GEMINI.md"]
 [features]
 memories = true
 
+# Telemetry: disable anonymous usage/health metrics sent to OpenAI (on by default since v0.128.0)
+[analytics]
+enabled = false
+
 # Session history
 [history]
 persistence = "save-all"


### PR DESCRIPTION


## Why
Codex CLI ships anonymous usage/health analytics enabled by default (since v0.128.0), periodically sending feature usage, plugin names, MCP server counts, and tool-call statistics to OpenAI. This repo pins codex-bin to v0.134.0 and connects directly to OpenAI (`model = "gpt-5.5"`) with no enterprise data-handling exemption — unlike Gemini (routed via Vertex AI) or Copilot (Business plan) — yet the config carried no opt-out, leaving it inconsistent with the repo's existing telemetry-minimization posture.

## What
- Opt out via the documented `[analytics]` table rather than a top-level `analytics = false`, which is not a recognized key and would be a silent no-op.
- Keep the setting in the user-level config (symlinked to `~/.codex/config.toml`), the only scope where Codex honors telemetry keys — it ignores them in project-local `.codex/config.toml` and warns at startup.
- Leave OpenTelemetry (`[otel]`) untouched since that exporter is opt-in and already off by default; only the default-on analytics path needed closing.

## References
N/A
