### PR TITLE
Pin OpenCode small model to local llama.cpp

### DIFF
--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -85,5 +85,6 @@
       }
     }
   },
-  "model": "llamacpp-local/qwen3.6-35b-a3b"
+  "model": "llamacpp-local/qwen3.6-35b-a3b",
+  "small_model": "llamacpp-local/qwen3.6-35b-a3b"
 }


### PR DESCRIPTION


## Why
OpenCode generates session titles (and other lightweight tasks) with a separate "small model," and when its bundled OpenCode/Zen provider is reachable it prefers Zen's `gpt-5-nano` for these — sending the first user message off-machine even though the primary model here is a local llama.cpp server. The config left `small_model` unset, so title generation was not pinned locally and would silently route to Zen the moment that provider became available (e.g. after an `opencode auth login`).

## What
- Pin `small_model` to the same local llama.cpp model rather than leaving it unset, closing the latent egress path outright instead of relying on the Zen provider never being authenticated.
- Reuse the existing local model instead of standing up a separate smaller one: the local server is already the trust boundary, and a second model would add maintenance for only marginal latency gains.
- Did not pursue a per-agent title override or an auto-title off-switch — OpenCode exposes neither; `small_model` is the single documented, global control point.
- Accepted trade-off: an upstream bug can make local title generation fail silently, but that only leaves sessions untitled (cosmetic) and never re-introduces egress, so privacy wins over the title.

## References
N/A
