### PR TITLE
Fetch nix-darwin over git protocol instead of GitHub archive

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -120,15 +120,15 @@
       "locked": {
         "lastModified": 1779036909,
         "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
-        "owner": "lnl7",
-        "repo": "nix-darwin",
+        "ref": "refs/heads/master",
         "rev": "56c666e108467d87d13508936aade6d567f2a501",
-        "type": "github"
+        "revCount": 2360,
+        "type": "git",
+        "url": "https://github.com/nix-darwin/nix-darwin"
       },
       "original": {
-        "owner": "lnl7",
-        "repo": "nix-darwin",
-        "type": "github"
+        "type": "git",
+        "url": "https://github.com/nix-darwin/nix-darwin"
       }
     },
     "nixpkgs": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,10 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     nix-darwin = {
-      url = "github:lnl7/nix-darwin";
+      # git+https (not github:) so the flake fetches via the git protocol instead
+      # of GitHub's archive/codeload endpoint, which intermittently 404s on
+      # SHA-addressed tarball requests. Tracks the renamed nix-darwin/nix-darwin repo.
+      url = "git+https://github.com/nix-darwin/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     home-manager = {


### PR DESCRIPTION


## Why
CI dry-run builds began failing intermittently while fetching the nix-darwin input: GitHub's archive/codeload endpoint returns a 404 on roughly one in three SHA-addressed tarball requests for this repo right now (the same `tarball/<sha>` URL was observed flipping 200/404/200 on consecutive calls). The `github:` flake fetcher relies on that endpoint, so every build had a high chance of failing even though the locked revision is healthy and is the current nix-darwin master tip.

## What
- Switch the input to the `git+https://` fetcher so resolution goes through the git smart-HTTP protocol — which `git ls-remote` confirmed is reliable — rather than the flaky archive endpoint. The locked revision is unchanged, so this is a fetch-path swap, not a dependency bump.
- Rejected the alternative of just re-running CI until green: with two build jobs each ~2/3 likely to succeed, a fully green run is only ~44% per attempt, and the flakiness would keep recurring on every future PR.
- Point at the canonical `nix-darwin/nix-darwin` location while here, since the old `lnl7/nix-darwin` name is now a redirect after the repo rename.
- Accepted trade-off: the git fetcher clones rather than downloading a tarball, so the first uncached fetch is marginally slower, but Nix caches it and the result evaluates identically.

## References
N/A
