### PR TITLE
Clarify that install cooldown applies to npm only, not pnpm/yarn

### DIFF
--- a/config/node/npmrc
+++ b/config/node/npmrc
@@ -3,5 +3,8 @@
 # Identity tracking and breach notifications are not provided in this mode.
 registry=https://npm.flatt.tech/
 # Client-side install cooldown in days, enforced by npm v11.10.0+.
-# pnpm/yarn use different keys (minimumReleaseAge) and ignore this harmlessly.
+# pnpm/yarn ignore this key and gate cooldown via their own config files,
+# so it cannot be enabled from ~/.npmrc:
+#   - pnpm: minimumReleaseAge (minutes) in pnpm-workspace.yaml; v11 defaults to 1440 (1d)
+#   - yarn berry: npmMinimalAgeGate (e.g. "1d") in .yarnrc.yml
 min-release-age=7


### PR DESCRIPTION


## Why
The npmrc comment described the `min-release-age` cooldown as something pnpm/yarn merely "ignore harmlessly," which understated the limitation: those tools cannot enable a cooldown from `~/.npmrc` at all. Left as-is, the comment risks implying the supply-chain cooldown protection spans every package manager, when in fact only npm honors this key.

## What
Documented the actual per-tool configuration surface instead of bolting a non-functional line onto `.npmrc`. Adding pnpm/yarn cooldown keys here was considered and rejected: both read their own files (pnpm reads `minimumReleaseAge` from `pnpm-workspace.yaml`, yarn berry reads `npmMinimalAgeGate` from `.yarnrc.yml`), so any `.npmrc` entry would be cargo-cult config that silently does nothing. The comment also records that pnpm v11 already defaults to a 1-day cooldown, so no project-level gating is needed today. Comment-only change with no behavioral effect; the Takumi Guard registry proxy remains the cross-tool malicious-package control.

## References
N/A
