### PR TITLE
Bump claude-code to v2.1.158 and opencode to v1.15.12

### DIFF
--- a/packages/claude-code-bin/default.nix
+++ b/packages/claude-code-bin/default.nix
@@ -7,10 +7,10 @@
   stdenvNoCC,
 }:
 let
-  version = "2.1.144";
+  version = "2.1.158";
   src = fetchurl {
     url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${version}/darwin-arm64/claude";
-    hash = "sha256-mIa6pOxMRV+GEIRk8SFzIZPuduXfzrAxAF9Z8xJ2pd8=";
+    hash = "sha256-U2oFF/pk1I3cvI61EaPQgCfUfgbRSIcjMqgEHXLCJ2g=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/opencode-bin/default.nix
+++ b/packages/opencode-bin/default.nix
@@ -9,11 +9,11 @@
   unzip,
 }:
 let
-  version = "1.15.11";
+  version = "1.15.12";
   asset = "opencode-darwin-arm64";
   src = fetchurl {
     url = "https://github.com/sst/opencode/releases/download/v${version}/${asset}.zip";
-    hash = "sha256-+C8L2yhYNpccY2d90Y1wBduvRr/QTiI4OQW/hFP024w=";
+    hash = "sha256-1lTw4/Ur26VgsarAIeH+x+9FbSGw8Cw7qCAoQ+c9vUU=";
   };
 in
 stdenvNoCC.mkDerivation {


### PR DESCRIPTION


## Why
The daily security audit flagged the pinned `claude-code-bin` v2.1.144 as sitting in the version range affected by a regression that forwarded the user's Anthropic OAuth credential to custom API gateways instead of the gateway's own token; the fix shipped in v2.1.153. The pinned `opencode-bin` v1.15.11 lags behind upstream stability fixes for `acp-next` session handling and OpenAI WebSocket transport.

## What
- For `claude-code-bin`, the choice was between the minimum-impact bump (v2.1.153, OAuth fix only) and the latest (v2.1.158, which also picks up the agent-tracking HTTP headers introduced in v2.1.154 plus Opus 4.8, dynamic workflows, and v2.1.157 plugin/agents fixes). Took v2.1.158: the new `x-claude-code-agent-id` / `x-claude-code-parent-agent-id` headers ride on essential `api.anthropic.com` traffic and carry only session/agent identifiers (no user data), and the matching OTEL span attributes are already dropped by the existing `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` setting in `config/claude/settings.json`. The marginal telemetry surface area is therefore zero in this configuration, while v2.1.158 also collapses several other unrelated bug fixes that would otherwise require follow-up bumps.
- For `opencode-bin`, v1.15.12 adds an ACP egress path (`acp-next` can now send prompts, slash commands, and usage updates to ACP integrations). The local `config/opencode/opencode.json` uses only `llamacpp-local` as a provider and the local `voicevox` MCP with no ACP integrations configured, so the new egress path is dormant and the bump is otherwise pure bugfix uptake.
- Did not run `nix flake update` even though the audit flagged curl CVE-2026-6253 and Nix daemon LPE GHSA-vh5x-56v6-4368 as "uncertain whether the locked rev is patched": direct evaluation of `pkgs.curl.version` against the locked nixpkgs returned `8.20.0` (fixed), and `config.nix.package.version` against the locked nix-darwin returned `2.34.7+1` (fixed). Both are out of scope for this PR.

## References
N/A
