### PR TITLE
Add license and attribution for empirical-prompt-tuning skill

### DIFF
--- a/config/agents/skills/empirical-prompt-tuning/LICENSE
+++ b/config/agents/skills/empirical-prompt-tuning/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 mizchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/config/agents/skills/empirical-prompt-tuning/README.md
+++ b/config/agents/skills/empirical-prompt-tuning/README.md
@@ -1,7 +1,7 @@
 # empirical-prompt-tuning
 
-Imported from [mizchi/skills](https://github.com/mizchi/skills).
+Adapted from [mizchi/skills](https://github.com/mizchi/skills).
 
 - Upstream source: [`meta/empirical-prompt-tuning/SKILL.md`](https://github.com/mizchi/skills/blob/085187056766abc994a0bd856c3158f41d2cf039/meta/empirical-prompt-tuning/SKILL.md) (a Japanese original, `SKILL-ja.md`, also exists upstream)
-- Status: `SKILL.md` is a verbatim copy of the English version at the pinned upstream commit; this `README.md` and `LICENSE` are local.
+- Status: `SKILL.md` is based on the English version at the pinned upstream commit, with local edits to unify the dispatch tool name to `Task tool` and clarify the parallelism trigger; this `README.md` and `LICENSE` are local.
 - License: MIT (see [`LICENSE`](./LICENSE)) -- Copyright (c) 2026 mizchi. Upstream carries no per-skill license file; per the [repository README](https://github.com/mizchi/skills#license), skills without an explicit license default to MIT at the owner's discretion.

--- a/config/agents/skills/empirical-prompt-tuning/README.md
+++ b/config/agents/skills/empirical-prompt-tuning/README.md
@@ -1,0 +1,7 @@
+# empirical-prompt-tuning
+
+Imported from [mizchi/skills](https://github.com/mizchi/skills).
+
+- Upstream source: [`meta/empirical-prompt-tuning/SKILL.md`](https://github.com/mizchi/skills/blob/085187056766abc994a0bd856c3158f41d2cf039/meta/empirical-prompt-tuning/SKILL.md) (a Japanese original, `SKILL-ja.md`, also exists upstream)
+- Status: `SKILL.md` is a verbatim copy of the English version at the pinned upstream commit; this `README.md` and `LICENSE` are local.
+- License: MIT (see [`LICENSE`](./LICENSE)) -- Copyright (c) 2026 mizchi. Upstream carries no per-skill license file; per the [repository README](https://github.com/mizchi/skills#license), skills without an explicit license default to MIT at the owner's discretion.

--- a/config/agents/skills/empirical-prompt-tuning/SKILL.md
+++ b/config/agents/skills/empirical-prompt-tuning/SKILL.md
@@ -29,7 +29,7 @@ When not to use:
 1. **Baseline preparation**: Fix the target prompt and prepare the following two things.
    - **Evaluation scenarios**, 2 to 3 kinds (1 median + 1 to 2 edge). Realistic tasks that assume actual situations where the target prompt would apply.
    - **Requirements checklist** (for computing accuracy). For each scenario, enumerate 3 to 7 items the deliverable must satisfy. Accuracy % = items satisfied / total items. Fix this in advance (do not move it afterward).
-2. **Bias-free read**: Have a "blank-slate" executor read the instruction. **Dispatch a new subagent** via the Task tool. Do not substitute with a self-reread (it is structurally impossible to view text you just wrote objectively). When running multiple scenarios in parallel, place multiple Agent invocations within a single message. For how to handle environments where dispatch is unavailable, see the "Environment constraints" section.
+2. **Bias-free read**: Have a "blank-slate" executor read the instruction. **Dispatch a new subagent** via the Task tool. Do not substitute with a self-reread (it is structurally impossible to view text you just wrote objectively). When running multiple scenarios in parallel, place multiple Task tool calls within a single message. For how to handle environments where dispatch is unavailable, see the "Environment constraints" section.
 3. **Execution**: Hand the subagent a prompt that follows the **subagent invocation contract** described below, and have it execute the scenario. The executor produces an implementation or output and returns a self-report at the end.
 4. **Two-sided evaluation**: Record the following from the returned results.
    - **Executor self-report** (extracted from the body of the subagent's report): unclear points / discretionary fill-ins / places where template application got stuck
@@ -46,7 +46,7 @@ When not to use:
 5. **Apply the diff**: Put the minimum fix into the prompt to eliminate the unclear points. One theme per iteration (multiple related fixes are OK, unrelated fixes go to next time).
    - **Before applying the fix, explicitly state "which item in the requirements checklist / judgment wording this fix satisfies"** (fixes inferred from axis names often do not land. See the "Fix propagation patterns" section below.)
    - **Consult the failure pattern ledger first**. If the structured reflection's `General Fix Rule` already matches a known pattern, the first question is "why didn't the existing fix prevent it?" — the fix may need to move closer to the top of the prompt, or be re-worded, before a new ledger entry is added.
-6. **Re-evaluate**: Run 2 → 5 again with a new subagent (do not reuse the same agent: it has learned the previous improvements). Increase parallelism if iterating further does not plateau improvements.
+6. **Re-evaluate**: Run 2 → 5 again with a new subagent (do not reuse the same agent: it has learned the previous improvements). Increase parallelism only once improvement has plateaued (it is a plateau-breaking tactic, not a default).
 7. **Convergence check**: The rough rule is "stop when 2 consecutive iterations have zero new unclear points AND metric improvements fall below the thresholds (below)". Make it 3 consecutive for high-importance prompts.
 
 ## Evaluation axes
@@ -124,7 +124,7 @@ You are an executor reading <target prompt name> with a blank slate.
 - Retries: number of times you redid the same decision and why
 ```
 
-The caller extracts the self-report portion from the report and fills the evaluation-axis table by obtaining `tool_uses` / `duration_ms` from the Agent tool's usage meta.
+The caller extracts the self-report portion from the report and fills the evaluation-axis table by obtaining `tool_uses` / `duration_ms` from the Task tool's usage meta.
 
 ## Environment constraints
 
@@ -171,7 +171,7 @@ When iterations approach a plateau but convergence criteria (2 consecutive clear
 - **Conservative variant**: current prompt + next-best minor fix
 - **Exploratory variant**: current prompt with one structural change — reorder sections, split a dense paragraph, drop a redundant section, or add a missing scaffolding (e.g., a worked example)
 
-Dispatch fresh subagents on the same scenarios in parallel (one message with multiple Agent tool calls). Keep the variant with higher accuracy; on tie, prefer fewer unclear points; on further tie, prefer lower `tool_uses`.
+Dispatch fresh subagents on the same scenarios in parallel (one message with multiple Task tool calls). Keep the variant with higher accuracy; on tie, prefer fewer unclear points; on further tie, prefer lower `tool_uses`.
 
 Pairwise-comparison caveats:
 - Do **not** ask a subagent to rate "A vs B" directly. LLM position bias and self-preference bias make such judgments noisy at small n.

--- a/config/agents/skills/empirical-prompt-tuning/SKILL.md
+++ b/config/agents/skills/empirical-prompt-tuning/SKILL.md
@@ -1,184 +1,245 @@
 ---
 name: empirical-prompt-tuning
-description: A method for iteratively improving agent-facing text instructions (skill / slash command / task prompt / CLAUDE.md section / code-generation prompt) by having an unbiased executor run them, then evaluating from both sides (executor self-report + instruction-side metrics). Loop until improvement plateaus. Use right after creating or significantly revising a prompt or skill, or when you suspect that an agent's failure to behave as expected stems from ambiguity on the instruction side.
+description: Methodology for iteratively improving agent-facing instructions (skills / slash commands / CLAUDE.md / code-gen prompts) via bias-free executor + two-sided evaluation (self-report + instruction-side metrics). Meta-skill, invoke ONLY when the user explicitly asks for an "empirical" eval of a prompt or skill, or for the Iter-0 description / body consistency check. Do NOT auto-invoke after every skill edit; this loop is operator-triggered by name.
 ---
 
 # Empirical Prompt Tuning
 
-The author of a prompt cannot judge its quality. The clearer it feels to the writer, the more often another agent stumbles over it. **Have an unbiased executor actually run it, evaluate from both sides, and iterate** — that is the core of this skill. Do not stop until improvement plateaus.
+The author of a prompt cannot judge its quality. The clearer the writer thinks something is, the more likely another agent will stumble on it. The core of this skill is to **have a bias-free executor actually run the instruction, evaluate it two-sidedly, and iterate**. Do not stop until improvements plateau.
 
 ## When to use
 
-- Right after creating or significantly revising a skill / slash command / task prompt
-- When an agent does not behave as expected and you want to attribute the cause to instruction-side ambiguity
-- When hardening high-importance instructions (frequently used skills, prompts at the core of automation)
+- Right after creating or substantially revising a skill / slash command / task prompt
+- When an agent does not behave as expected and you want to attribute the cause to ambiguity on the instruction side
+- When hardening high-importance instructions (frequently used skills, automation-core prompts)
 
 When not to use:
-- One-off, throwaway prompts (the evaluation cost is not worth it)
-- When the goal is not improving success rate but reflecting the writer's subjective preference
+- One-off throwaway prompts (evaluation cost does not pay off)
+- When the goal is not to improve success rate but merely to reflect the writer's subjective preferences
 
 ## Workflow
 
-0. **Iteration 0 — alignment check between description and body** (static, no dispatch)
-   - Read the trigger / use cases the frontmatter `description` claims
+0. **Iteration 0 — description / body consistency check** (static, no dispatch needed)
+   - Read the triggers / use cases claimed by the frontmatter `description`
    - Read the scope the body actually covers
-   - If they diverge, fix description or body to match before proceeding to iter 1
-   - Example: detect cases like `description` saying "navigation / form filling / data extraction" while the body only contains a `npx playwright test` CLI reference
-   - If you skip this, the subagent will "reinterpret" the body to match the description, and accuracy comes out fine even though the skill does not actually meet the requirements (false positive)
+   - If there is a gap, reconcile description or body before moving to iter 1
+   - Example: description says "navigation / form filling / data extraction" but the body is only a CLI reference for `npx playwright test` — detect that kind of gap
+   - If you skip this, the subagent will "reinterpret" the body to match the description, and accuracy will come out high even though the skill does not actually meet the requirements (false positive)
 
-1. **Baseline preparation**: fix the target prompt and prepare the following two:
-   - **Evaluation scenarios**, 2 to 3 (1 median + 1 to 2 edge). Tasks that could realistically occur, simulating situations where the target prompt is actually applied.
-   - **Requirements checklist** (for accuracy calculation). For each scenario, list 3 to 7 items the deliverable must satisfy. Accuracy % = items satisfied / total items. Fix this in advance (do not move it later).
-2. **Bias-free read**: have a "blank" executor read the instructions. **Dispatch a fresh subagent** via the Agent tool. Do not settle for self-rereading (it is structurally impossible to view text you just wrote objectively). When running multiple scenarios in parallel, place multiple Agent tool calls in a single message. For environments where dispatch is unavailable, see the "Environment constraints" section.
-3. **Execution**: hand the subagent a prompt that follows the **subagent invocation contract** below and have it run the scenario. The executor produces an implementation or output, then returns a self-report at the end.
-4. **Two-sided evaluation**: from the returned result, record the following.
-   - **Executor self-report** (extracted from the body of the subagent's report): ambiguities / discretionary completions / spots where template application got stuck
-   - **Instruction-side metrics** (judgement rules are defined in this section as the single source of truth; other places reference back here):
-     - Success/failure: success (○) only when **all** items tagged `[critical]` are ○. If even one is × or partial, it is failure (×). Labels are binary, ○ / × only.
-     - Accuracy (achievement rate of the requirements checklist, as %. ○ = full mark, × = 0, partial = 0.5; sum and divide by total items)
-     - Step count (use the `tool_uses` value in the usage metadata returned by the Agent tool as is. Include Read / Grep — do not exclude them.)
-     - Duration (`duration_ms` from the Agent tool usage metadata)
-     - Retry count (how many times the subagent redid the same judgement. Extracted from the subagent's self-report; not measurable on the instruction side.)
-     - **On failure, add a one-liner under "ambiguities" in the presentation format saying which `[critical]` item dropped** (for cause tracking)
-   - The requirements checklist must contain **at least one** `[critical]`-tagged item (with zero, the success judgement becomes vacuous). Do not add or remove `[critical]` after the fact.
-5. **Apply diff**: introduce the minimal edit that closes the ambiguities into the prompt. One theme per iteration (multiple related edits are fine; unrelated edits go to the next iteration).
-6. **Re-evaluate**: dispatch a new subagent and run 2 → 5 again (do not reuse the same agent: it has learned from the previous improvement). Increase parallelism only if iterations stop producing improvement.
-7. **Convergence check**: rough rule — stop when "two consecutive iterations show zero new ambiguities AND metric improvement below the threshold (see below)". For high-importance prompts, require three consecutive.
+1. **Baseline preparation**: Fix the target prompt and prepare the following two things.
+   - **Evaluation scenarios**, 2 to 3 kinds (1 median + 1 to 2 edge). Realistic tasks that assume actual situations where the target prompt would apply.
+   - **Requirements checklist** (for computing accuracy). For each scenario, enumerate 3 to 7 items the deliverable must satisfy. Accuracy % = items satisfied / total items. Fix this in advance (do not move it afterward).
+2. **Bias-free read**: Have a "blank-slate" executor read the instruction. **Dispatch a new subagent** via the Task tool. Do not substitute with a self-reread (it is structurally impossible to view text you just wrote objectively). When running multiple scenarios in parallel, place multiple Agent invocations within a single message. For how to handle environments where dispatch is unavailable, see the "Environment constraints" section.
+3. **Execution**: Hand the subagent a prompt that follows the **subagent invocation contract** described below, and have it execute the scenario. The executor produces an implementation or output and returns a self-report at the end.
+4. **Two-sided evaluation**: Record the following from the returned results.
+   - **Executor self-report** (extracted from the body of the subagent's report): unclear points / discretionary fill-ins / places where template application got stuck
+   - **Trace interpretation**: each unclear point is tagged with the phase it originated in (Understanding / Planning / Execution / Formatting — see "Subagent invocation contract"). Phase-local fixes land better than global "the prompt was unclear" fixes; a single Understanding-phase ambiguity often looks like a chain of Execution-phase failures.
+   - **Structured reflection**: each unclear point must be returned as `Issue / Cause / General Fix Rule`. The `General Fix Rule` is the class-level abstraction that feeds the "Failure pattern ledger" — without it, fixes stay as one-off patches that rediscover the same mistake later.
+   - **Instruction-side measurements** (the judgment rules are defined canonically in this section; refer to it from elsewhere):
+     - Success/failure: counts as success (○) only when **all** requirements tagged `[critical]` are ○. If even one is × or partial, it is failure (×). The label is the binary ○ / × only.
+     - Accuracy (achievement rate of the requirements checklist, %. ○ = full score, × = 0, partial = 0.5; sum and divide by total items)
+     - Step count (use the `tool_uses` field in the usage meta attached to the Task tool return value as-is. Include Read / Grep, do not exclude them)
+     - Duration (`duration_ms` from the Task tool usage meta)
+     - Retry count (how many times the subagent redid the same decision. Extract from the subagent's self-report; not measurable from the instruction side)
+     - **On failure, add a one-line note to the "unclear points" section of the presentation format stating "which [critical] item dropped"** (for root cause tracing)
+   - The requirements checklist must include **at least one** `[critical]`-tagged item (if there are zero, the success judgment becomes vacuous). Do not add or remove [critical] tags after the fact.
+5. **Apply the diff**: Put the minimum fix into the prompt to eliminate the unclear points. One theme per iteration (multiple related fixes are OK, unrelated fixes go to next time).
+   - **Before applying the fix, explicitly state "which item in the requirements checklist / judgment wording this fix satisfies"** (fixes inferred from axis names often do not land. See the "Fix propagation patterns" section below.)
+   - **Consult the failure pattern ledger first**. If the structured reflection's `General Fix Rule` already matches a known pattern, the first question is "why didn't the existing fix prevent it?" — the fix may need to move closer to the top of the prompt, or be re-worded, before a new ledger entry is added.
+6. **Re-evaluate**: Run 2 → 5 again with a new subagent (do not reuse the same agent: it has learned the previous improvements). Increase parallelism if iterating further does not plateau improvements.
+7. **Convergence check**: The rough rule is "stop when 2 consecutive iterations have zero new unclear points AND metric improvements fall below the thresholds (below)". Make it 3 consecutive for high-importance prompts.
 
 ## Evaluation axes
 
-| Axis | How to take it | Meaning |
+| Axis | How to capture | Meaning |
 |---|---|---|
-| Success/failure | Whether the executor produced the intended deliverable (binary) | Minimum bar |
-| Accuracy | What % of the requirements the deliverable met | Degree of partial success |
-| Step count | Number of tool calls / decision steps the executor used | Indicator of instruction waste |
-| Duration | Executor's `duration_ms` | Proxy for cognitive load |
-| Retry count | How many times the same judgement was redone | Signal of instruction ambiguity |
-| Ambiguities (self-reported) | Listed by the executor as bullet points | Qualitative material for improvement |
-| Discretionary completions (self-reported) | Decisions not specified in the instructions | Surfacing of implicit specs |
+| Success/failure | Did the executor produce the intended deliverable (binary) | Minimum bar |
+| Accuracy | What % of requirements the deliverable satisfies | Degree of partial success |
+| Step count | Tool-call / decision-step count used by the executor | Indicator of instruction waste |
+| Duration | Executor's duration_ms | Proxy indicator of cognitive load |
+| Retry count | How many times the same decision was redone | Signal of instruction ambiguity |
+| Unclear points (self-report) | Executor enumerates as bullets | Qualitative improvement material |
+| Discretionary fill-ins (self-report) | Decisions not fixed by the instruction | Surfaces implicit specification |
 
-**Weighting**: qualitative (ambiguities, discretionary completions) is primary; quantitative (duration, step count) is secondary. Chasing only time reduction makes the prompt overly thin.
+**Weighting**: Qualitative (unclear points / discretionary fill-ins) is primary, quantitative (time / step count) is auxiliary. Chasing only time reduction makes the prompt too thin.
 
 ### Qualitative interpretation of `tool_uses`
 
-Looking only at accuracy hides skill-level problems. Using `tool_uses` as a **relative value across scenarios** reveals structural defects:
+Looking only at accuracy hides skill problems. Using `tool_uses` as a **relative value across scenarios** reveals structural defects:
 
-- If one scenario is **3-5x or more** of the others, that skill leans toward a **decision-tree index with low self-containedness**. The executor is being forced into references descent.
-- Typical example: all scenarios show `tool_uses` of 1-3, but one scenario shows 15+ → the skill lacks an inline recipe for that scenario, and the executor is sweeping across `references/`.
-- Remedy: in iter 2, add a "minimal complete example inline" or "guidance on when to read references" near the top of SKILL.md, and `tool_uses` drops sharply.
+- If one scenario is **3-5x or more** vs the others, that skill is a sign of being **decision-tree-index-leaning with low self-containment**. The executor is being forced into references descent.
+- Typical example: all scenarios have `tool_uses` of 1-3 but one scenario alone has 15+ → there is no recipe for that scenario in the skill itself, so it is cross-searching references/
+- Countermeasure: adding an "inline minimum complete example" or "guidance on when to read references" at the top of SKILL.md in iter 2 significantly drops `tool_uses`
 
-Even at 100% accuracy, a `tool_uses` skew is grounds to trigger iter 2. "Judging only by accuracy and stopping" tends to miss structural defects.
+Even at 100% accuracy, a skew in `tool_uses` is grounds for triggering iter 2. "Cut off based on accuracy alone" tends to miss structural defects.
+
+### Fix propagation patterns (conservative / overshoot / zero-shoot)
+
+Fix → effect is not linear. Pre-estimation can play out in the following 3 patterns:
+
+- **Conservative swing** (estimate > actual): one fix aimed at multiple axes but only moved one. "Aiming at multiple axes tends to miss."
+- **Overshoot** (estimate < actual): one structural piece of information (e.g., a combination of command + config + expected output) satisfied judgment wording across multiple axes at once. "Combinations of information structurally hit multiple axes."
+- **Zero-shoot** (estimate > 0, actual = 0): a fix inferred from the axis name did not reach any of the judgment wording. "Axis names and judgment wording are different things."
+
+To stabilize this, **before applying the diff, have the subagent verbalize "which judgment wording this fix satisfies"**. Estimation accuracy does not come out unless you tie things at the threshold-wording level. When adding a new evaluation axis, also concretize the judgment criteria for each point down to the threshold-wording level (at a granularity the subagent can judge, such as "all explicit" or "full text of a minimum working configuration" — so it knows what constitutes 2 points).
 
 ## Subagent invocation contract
 
-The prompt handed to the executor takes the following structure. This is the input contract for "two-sided evaluation".
+The prompt given to the executor takes the following structure. This is the input contract for "two-sided evaluation".
 
 ```
 You are an executor reading <target prompt name> with a blank slate.
 
-## Mode
-empirical  # change to "structural" for textual consistency check only (see "Environment constraints: Structural review mode")
-
 ## Target prompt
-<paste the full body of the target prompt, or specify the path to Read>
+<Paste the full body of the target prompt, or specify a path for Read>
 
 ## Scenario
-<one paragraph describing the scenario's situation>
+<One paragraph setting the scenario context>
 
 ## Requirements checklist (items the deliverable must satisfy)
 1. [critical] <item that belongs to the minimum bar>
-2. <regular item>
-3. <regular item>
+2. <normal item>
+3. <normal item>
 ...
+(Judgment rules are canonically defined in "Workflow 4. Two-sided evaluation / Instruction-side measurements". At least one [critical] is required.)
 
 ## Task
 1. Follow the target prompt to execute the scenario and produce the deliverable.
-2. On finish, reply using the report structure below.
+2. On completion, respond with the report structure below.
 
 ## Report structure
-- Deliverable: <output or summary of execution result>
-- Requirement satisfaction: ○ / × / partial (with reason) for each item
-- Ambiguities: spots in the target prompt where you got stuck or wording you struggled to interpret (bullets)
-- Discretionary completions: spots not specified in the instructions where you filled in based on your own judgement (bullets)
-- Retries: how many times you redid the same judgement, and why
+- Deliverable: <artifact or execution summary>
+- Requirement achievement: ○ / × / partial (with reason) for each item
+- **Trace** (tag OK / stuck / skipped for each phase, one-line reason when not OK):
+  - Understanding (reading the instruction and building a mental model)
+  - Planning (deciding the approach / ordering)
+  - Execution (actually doing the work)
+  - Formatting (shaping the deliverable to the expected form)
+  - *Collapsed form allowed*: when all four phases are OK, a single line `Trace: all OK` is sufficient. Emit phase-by-phase only when any phase is stuck or skipped. (This avoids happy-path boilerplate; the trace structure only earns its cost when something actually goes wrong.)
+- **Unclear points (structured)**: for each issue, three lines:
+  - Issue: <what observably happened>
+  - Cause: <why, diagnosed at the instruction level>
+  - General Fix Rule: <a class-level rule, not a spot fix, that would prevent this class of mistake>
+- Discretionary fill-ins: places not fixed by the instruction and filled in by your own judgment (bullets)
+- Retries: number of times you redid the same decision and why
 ```
 
-> Judgement rules are defined as the single source of truth in "Workflow 4. Two-sided evaluation / Instruction-side metrics". At least one [critical] is required.
-
-The caller extracts the self-report portion from the report and pulls `tool_uses` / `duration_ms` from the Agent tool's usage metadata to fill in the evaluation axes table.
+The caller extracts the self-report portion from the report and fills the evaluation-axis table by obtaining `tool_uses` / `duration_ms` from the Agent tool's usage meta.
 
 ## Environment constraints
 
-In environments where dispatching a fresh subagent is not possible (already running as a subagent, the Agent tool is disabled, etc.), this skill **does not apply**.
-- Alternative 1: ask the user of the parent session to launch a separate Claude Code session and run it
-- Alternative 2: skip the evaluation and explicitly report to the user "empirical evaluation skipped: dispatch unavailable"
-- **NG**: substituting self-rereading (bias creeps in, so the evaluation result cannot be trusted)
+In environments where dispatching a new subagent is not possible (already running as a subagent, Task tool is disabled, etc.), **do not apply** this skill.
+- Alternative 1: ask the parent session's user to start a separate Claude Code session and delegate the evaluation there
+- Alternative 2: give up on evaluation and explicitly report to the user "empirical evaluation skipped: dispatch unavailable"
+- **NG**: substitute with a self-reread (bias enters, so you must not trust the evaluation result)
 
-**Structural review mode**: when you only want to check **textual consistency and clarity** of a skill / prompt rather than empirical evaluation, switch into structural review mode explicitly. State "this round is structural review mode: textual consistency check, not execution" in the request prompt to the subagent. This way the subagent does not fall into the skip behaviour from the environment-constraints section and can return a static review. Structural review supplements, not substitutes, empirical evaluation (it cannot count toward consecutive-clear judgement).
+**Structural review mode**: when you want to check only the **consistency and clarity of the description** of the skill / prompt rather than run empirical evaluation, carve it out explicitly as structural review mode. Note clearly in the request prompt to the subagent "this round is structural review mode: text consistency check, not execution". That way the subagent will not trip on the skip behavior in the environment-constraints section and can return a static review. Structural review is an aid to empirical, not a replacement (it cannot be used for consecutive-clear judgment).
 
-## Stopping criteria
+## Iteration stopping criteria
 
-- **Convergence (stop)**: two consecutive rounds satisfying **all** of:
-  - New ambiguities: 0
-  - Accuracy improvement vs. previous: +3 percentage points or less (saturation, like 5% → 8%)
-  - Step-count change vs. previous: within ±10% (or ±1 step, whichever is larger)
-  - Duration change vs. previous: within ±15%
-  - **Overfitting check**: at convergence, add one previously-unused hold-out scenario and evaluate. If accuracy drops 15 percentage points or more from the recent average, that is overfitting. Go back to baseline scenario design and add edge cases.
-- **Divergence (suspect the design)**: if 3+ iterations fail to reduce new ambiguities → the prompt's design direction itself may be wrong. Stop patching and rewrite the structure.
-- **Resource cutoff**: when importance and improvement cost no longer balance, stop (the call to ship at 80%).
+- **Convergence (stop)**: 2 consecutive rounds satisfying **all** of the following:
+  - New unclear points: 0
+  - Accuracy improvement vs previous: +3 points or less (saturation such as 5% → 8%)
+  - Step count variation vs previous: within ±10%
+  - Duration variation vs previous: within ±15%
+  - **Overfitting check**: at convergence judgment, add 1 hold-out scenario not used so far and evaluate. If accuracy drops 15 points or more from the recent average, overfitting. Go back to baseline scenario design and add edges.
+- **Divergence (suspect the design)**: if new unclear points do not decrease across 3+ iterations → the design direction of the prompt itself may be wrong. Stop fixing by patches and rewrite the structure
+- **Resource cutoff**: stop when importance and improvement cost no longer balance (the "ship at 80 points" call)
+
+## Failure pattern ledger
+
+Maintain a cumulative list of failure modes across iterations. Without it, each iteration re-discovers the same class of mistake, and accuracy improvements stall without the operator noticing that the same `General Fix Rule` keeps surfacing under different surface wording.
+
+Entry format:
+
+```
+- **Pattern name**: short descriptive handle (not "ambiguous X"; prefer "over-eager template application when skip clause is absent")
+  - Example: <representative Issue wording from some iter>
+  - General Fix Rule: <the class-level rule from that iter's structured reflection>
+  - Seen in: iter N, iter M, ...
+```
+
+Rules:
+- Before generating a fix in Workflow step 5, scan the ledger. If the current `General Fix Rule` matches an existing entry, update `Seen in` and investigate why the existing fix did not prevent recurrence (wording ambiguity? position too late in the prompt? missing example?) before creating a new entry.
+- A pattern that recurs 3+ times despite targeted fixes is a structural signal — escalate to the "Divergence" criterion above rather than continuing to patch.
+- The ledger is per-target-prompt, not global across all empirical-prompt-tuning runs.
+
+## Variant exploration (optional, plateau-breaking)
+
+When iterations approach a plateau but convergence criteria (2 consecutive clears) are not met, suspect local optimum and run a 2-variant round:
+
+- **Conservative variant**: current prompt + next-best minor fix
+- **Exploratory variant**: current prompt with one structural change — reorder sections, split a dense paragraph, drop a redundant section, or add a missing scaffolding (e.g., a worked example)
+
+Dispatch fresh subagents on the same scenarios in parallel (one message with multiple Agent tool calls). Keep the variant with higher accuracy; on tie, prefer fewer unclear points; on further tie, prefer lower `tool_uses`.
+
+Pairwise-comparison caveats:
+- Do **not** ask a subagent to rate "A vs B" directly. LLM position bias and self-preference bias make such judgments noisy at small n.
+- Compare on the objective axes only (accuracy, step count, unclear-points count, phase-weakness counts). Those are reproducible; "which prompt felt better" is not.
+- If qualitative comparison is genuinely needed, counterbalance: run both orderings (A,B) and (B,A) and accept a verdict only if both orderings agree.
+
+Cost: variant exploration doubles dispatch count per iteration. Use when plateau is suspected, not by default.
 
 ## Presentation format
 
-Record and present each iteration to the user in this form:
+Record and present to the user with the following form at each iteration:
 
 ```
 ## Iteration N
 
-### Changes (diff vs. previous)
-- <one-line description of the edit>
+### Changes (diff from previous)
+- <one-line fix content>
+- Pattern applied: <pattern name from ledger, or "(new)">
 
-### Results (per scenario)
-| Scenario | Success/Failure | Accuracy | steps | duration | retries |
-|---|---|---|---|---|---|
-| A | ○ | 90% | 4 | 20s | 0 |
-| B | × | 60% | 9 | 41s | 2 |
+### Execution results (per scenario)
+| Scenario | Success/Failure | Accuracy | steps | duration | retries | Weak phase |
+|---|---|---|---|---|---|---|
+| A | ○ | 90% | 4 | 20s | 0 | — |
+| B | × | 60% | 9 | 41s | 2 | Execution |
 
-### Ambiguities (newly observed this round)
-- <Scenario B>: [critical] item N was × — <one-line reason for the drop>   # always include on failure
-- <Scenario B>: <other observation, one line>
-- <Scenario A>: (none new)
+### Structured reflection (newly surfaced this time)
+- <Scenario B>: [critical] item N is × — <one-line reason for drop>
+  - Issue: <what observably happened>
+  - Cause: <why, at the instruction level>
+  - General Fix Rule: <class-level abstraction>
+- <Scenario A>: (nothing new)
 
-### Discretionary completions (newly observed this round)
-- <Scenario B>: <what was filled in>
+### Discretionary fill-ins (newly surfaced this time)
+- <Scenario B>: <fill-in content>
 
-### Next edit
-- <minimal edit, one line>
+### Ledger updates
+- Added: <pattern name> (from Scenario B)
+- Re-seen: <pattern name> (originally iter K) — existing fix did not prevent recurrence because <reason>
 
-(Convergence: X consecutive clears / Y rounds remaining to stop)
+### Next fix proposal
+- <one-line minimum fix>
+
+(Convergence check: X consecutive clears / Y rounds remaining to stop condition)
 ```
 
-## Red flags (watch for rationalization)
+## Red flags (beware of rationalization)
 
-| The rationalization that surfaces | The reality |
+| Rationalization that surfaces | Reality |
 |---|---|
-| "Rereading it myself produces the same effect" | You cannot "objectively view" text you just wrote. Always dispatch a fresh subagent. |
-| "One scenario is enough" | One scenario overfits. Two minimum, three preferred. |
-| "Zero ambiguities once is the end" | It can be coincidence. Confirm with two consecutive rounds. |
-| "Let's crush multiple ambiguities at once" | You lose track of what worked. One theme per iteration. |
-| "Let's split related minor edits one-per-iteration too" | The opposite trap. "One theme" is a semantic unit. 2-3 related minor edits in a single iter is fine. Splitting too far makes iter count explode. |
-| "Metrics look good, ignore the qualitative feedback" | Time reduction can also signal thinning. Qualitative is primary. |
-| "It is faster to rewrite from scratch" | If 3+ rounds fail to reduce ambiguities, that is the right call. Before that point it is escapism. |
-| "Let's reuse the same subagent" | It has learned the previous improvement. Dispatch fresh every time. |
+| "Rereading it myself has the same effect" | You cannot view text you just wrote "objectively". Always dispatch a new subagent. |
+| "One scenario is enough" | One scenario overfits. Minimum 2, ideally 3. |
+| "Zero unclear points once, so we're done" | Could be coincidence. Finalize with 2 consecutive rounds. |
+| "Let's knock out multiple unclear points at once" | You lose track of what worked. One theme per iteration. |
+| "Split each related micro-fix strictly into its own iter" | Trap in the opposite direction. "One theme" is a semantic unit. 2-3 related micro-fixes can be bundled into 1 iter. Splitting too far explodes the iter count. |
+| "Metrics are good, so ignore qualitative feedback" | Time reduction can also be a sign of being too thin. Keep qualitative primary. |
+| "Rewriting from scratch is faster" | Correct if unclear points do not decrease across 3+ iterations. Before that stage, it is escape. |
+| "Let's reuse the same subagent" | It has learned the previous improvements. Always dispatch a new one. |
 
 ## Common failures
 
-- **Scenario too easy / too hard**: neither produces signal. One median plus one edge from real usage situations.
-- **Looking only at metrics**: chasing only time reduction strips out important explanation and makes the prompt brittle.
-- **Too many changes per iteration**: you lose track of "which of those edits worked". One edit, one iteration.
-- **Tuning scenarios to match the edits**: making scenarios easier so ambiguities appear to be resolved → backwards.
+- **Scenario too easy / too hard**: neither produces signal. One at the median of real use, one edge
+- **Only looking at metrics**: chasing only time reduction strips important explanations and makes it fragile
+- **Too many changes per iteration**: you can no longer trace "which fix back then worked". One fix per iteration
+- **Tuning scenarios to match the fix**: making the scenario side easier just to make unclear points look eliminated → putting the cart before the horse
 
 ## Related
 
-- `superpowers:writing-skills` — TDD approach for skill creation. Essentially the same as this skill's "subagent baseline → edit → re-run" loop.
-- `retrospective-codify` — codifying lessons after a task. Use this skill during prompt development; use `retrospective-codify` after a task ends.
-- `superpowers:dispatching-parallel-agents` — etiquette for running multiple scenarios in parallel.
+- `superpowers:writing-skills` — the TDD approach for skill creation. Essentially the same as this skill's "baseline → fix → rerun with a subagent"
+- `retrospective-codify` — fixating learnings after a task. This skill is during prompt development, retrospective-codify is after a task ends; use them differently
+- `superpowers:dispatching-parallel-agents` — conventions for running multiple scenarios in parallel
+- `waxa-eval` — operating manual for the `waxa` CLI, which automates the eval / iterate loop into an external process with a YAML scenario format and persistent ledger. This skill (empirical-prompt-tuning) covers the **methodology and the in-session Task-tool subagent flow**; `waxa-eval` covers the **CLI operation and YAML authoring**. They are complementary — use empirical for the Iter 0 static check, the `[critical]`-tagged checklist, and `tool_uses`-based skill diagnosis (none of which are accessible to a CLI process); use waxa-eval when persistence, CI repeatability, or external adoption gates are needed.


### PR DESCRIPTION


## Why
The empirical-prompt-tuning skill shipped as a locally-reworded English rendering of mizchi's upstream skill, with no license file and no record of where it came from. Unlike the grill-me skill — which documents its upstream source, pinned commit, and license — this skill left its provenance and licensing terms unstated, and its hand-maintained wording had already drifted from upstream.

## What
- Followed the convention grill-me established: a per-skill `LICENSE` plus a `README.md` that pins the exact upstream commit, so every imported skill carries the same auditable provenance trail.
- Chose to replace the diverged local prose with a verbatim copy of the upstream English `SKILL.md` rather than keep maintaining a separate translation. Verbatim tracking is cheaper to re-sync and removes the risk of silent drift; the cost is that local tuning is no longer carried, which we accepted.
- Recorded the license as MIT (Copyright mizchi). Upstream has no per-skill license file, but its repository README states that unlicensed skills default to MIT at the owner's discretion, which is the basis used here.
- Note: the upstream description marks this as a meta-skill that is operator-triggered by name and explicitly not auto-invoked. Adopting the verbatim copy therefore changes invocation behavior compared to the prior local version; this was accepted as part of staying in sync.

## References
N/A
