### PR TITLE
Assign per-mode models to opencode plan, build, and review agents

### DIFF
--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -40,6 +40,7 @@
     "plan": {
       "description": "Use only for non-trivial changes: unfamiliar subsystem, multi-file edits, unclear design, or risky behavior changes. Read code, identify existing patterns/utilities, and return a concise implementation plan. Do not edit files.",
       "mode": "primary",
+      "model": "opencode-go/kimi-k2.6",
       "steps": 10,
       "temperature": 0.1,
       "permission": {
@@ -61,6 +62,7 @@
     "review": {
       "description": "Read-only code reviewer. Inspect the current git diff first, then read touched files as needed. Flag correctness risks, regressions, security issues, and missing tests. Do not edit files.",
       "mode": "subagent",
+      "model": "opencode-go/kimi-k2.6",
       "steps": 8,
       "temperature": 0.1,
       "permission": {
@@ -85,6 +87,6 @@
       }
     }
   },
-  "model": "llamacpp-local/qwen3.6-35b-a3b",
+  "model": "opencode-go/glm-5.1",
   "small_model": "llamacpp-local/qwen3.6-35b-a3b"
 }


### PR DESCRIPTION


## Why
The opencode setup ran every mode on a single default model (the local llama.cpp build), so planning, implementation, and review all shared one model's strengths and blind spots. With an active OpenCode Go subscription available, the catalog's specialized open models can now be matched to the capability each phase actually leans on.

## What
- Matched each mode to the capability that phase depends on: planning and review favor reasoning and bug-finding, while implementation favors coding/agentic throughput. Kimi K2.6 (the strongest open reasoner in the Go catalog) drives plan and review; GLM-5.1 (coding-specialized) drives build.
- Deliberately gave review a different model from build. A reviewer running the same model as the implementer tends to share its blind spots and rationalize its own output; a separate model is more likely to catch what the build model missed.
- Considered a single strong all-rounder (Kimi everywhere) but rejected it — GLM is more cost-effective and coding-tuned for the high-volume build path, and cross-phase model diversity is itself a benefit.
- Kept small_model on the free local model rather than a Go model: lightweight housekeeping (title generation, etc.) does not justify metered usage. The accepted trade-off is that this path still depends on the local llama-server being up.

## References
N/A
