### PR TITLE
Extend Takumi Guard supply-chain protection to Yarn Berry

### DIFF
--- a/config/node/npmrc
+++ b/config/node/npmrc
@@ -5,6 +5,8 @@ registry=https://npm.flatt.tech/
 # Client-side install cooldown in days, enforced by npm v11.10.0+.
 # pnpm/yarn ignore this key and gate cooldown via their own config files,
 # so it cannot be enabled from ~/.npmrc:
-#   - pnpm: minimumReleaseAge (minutes) in pnpm-workspace.yaml; v11 defaults to 1440 (1d)
-#   - yarn berry: npmMinimalAgeGate (e.g. "1d") in .yarnrc.yml
+#   - pnpm: minimumReleaseAge (minutes) in pnpm-workspace.yaml ONLY -- pnpm
+#     docs state it cannot be set globally; per-project file required.
+#     v11+ already defaults to 1440 (1d).
+#   - yarn berry: npmMinimalAgeGate set to "7d" in config/node/yarnrc.yml
 min-release-age=7

--- a/config/node/yarnrc.yml
+++ b/config/node/yarnrc.yml
@@ -1,0 +1,11 @@
+# Yarn Berry global config (~/.yarnrc.yml). Yarn does NOT read ~/.npmrc, so the
+# Takumi Guard proxy and release-age gate defined in config/node/npmrc do not
+# reach yarn -- they must be restated here.
+
+# Takumi Guard registry proxy (https://flatt.tech/takumi/features/guard).
+# Anonymous mode -- no token required for the package-blocking feature.
+npmRegistryServer: "https://npm.flatt.tech/"
+
+# Minimum publish age before a version is installable. Mirrors npm's
+# min-release-age=7 (7 days) from config/node/npmrc.
+npmMinimalAgeGate: "7d"

--- a/modules/shared/node.nix
+++ b/modules/shared/node.nix
@@ -7,9 +7,18 @@
 {
   # npm registry routed through Takumi Guard's malicious-package blocking
   # proxy (https://flatt.tech/takumi/features/guard). Anonymous mode --
-  # no token required. Applies to npm/pnpm/yarn/npx.
+  # no token required. ~/.npmrc covers npm/pnpm/npx (pnpm reads npm-style
+  # config); yarn berry ignores ~/.npmrc and is configured via ~/.yarnrc.yml
+  # below.
   home.file.".npmrc" = {
     source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/node/npmrc";
+    force = true;
+  };
+
+  # Yarn berry does not read ~/.npmrc, so the registry proxy and release-age
+  # gate must be restated here for yarn to honor them.
+  home.file.".yarnrc.yml" = {
+    source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/node/yarnrc.yml";
     force = true;
   };
 }


### PR DESCRIPTION


## Why
The Takumi Guard registry proxy and release-age gate were only configured in `~/.npmrc`, but Yarn Berry does not read `~/.npmrc` at all. As a result Yarn invocations silently bypassed the malicious-package blocking proxy and had no install cooldown, despite the module comment claiming the protection applied to yarn. This left a supply-chain gap precisely where it was least likely to be noticed.

## What
- Restate the registry proxy and a 7-day publish-age gate in a yarn-native config file, keeping the file-based, per-tool style already used for npm rather than scattering settings into env vars.
- Rejected the `YARN_*` environment-variable approach: it splits the config mechanism away from the existing npmrc file and would miss non-shell launches. Yarn has no XDG support (global config is fixed at the home file), so relocating it was not an option either.
- Deliberately left pnpm without a global gate: its `minimumReleaseAge` is settable only per-project (`pnpm-workspace.yaml`), and v11+ already defaults to a 1-day cooldown. The comment is updated to record this constraint instead of shipping config that pnpm would ignore.

## References
- #107
