### PR TITLE
Add git-tools package and drop the bespoke git-clean script

### DIFF
--- a/modules/shared/git.nix
+++ b/modules/shared/git.nix
@@ -28,42 +28,13 @@ let
 
     exec ${pkgs.gitleaks}/bin/gitleaks protect --staged --redact --verbose
   '';
-
-  git-clean = pkgs.writeShellScriptBin "git-clean" ''
-    #!/bin/sh
-
-    # Identify merged branches that can be deleted
-    BRANCHES_TO_DELETE=$(git branch --merged | grep -v "^\*\|main\|master\|develop")
-
-    # Exit with a message if there are no branches to delete
-    if [ -z "$BRANCHES_TO_DELETE" ]; then
-      echo "No merged branches to delete! Your repository is clean."
-      exit 0
-    fi
-
-    # Display the branches that will be deleted
-    echo "The following merged branches will be deleted:"
-    echo "$BRANCHES_TO_DELETE"
-
-    # Ask for confirmation
-    echo -n "Do you want to delete these branches? [y/N]: "
-    read ANSWER
-
-    # Only delete if confirmed
-    if [ "$ANSWER" = "y" ] || [ "$ANSWER" = "Y" ]; then
-      echo "$BRANCHES_TO_DELETE" | xargs git branch -d
-      echo "Branch cleanup completed successfully!"
-    else
-      echo "Branch deletion canceled."
-    fi
-  '';
 in
 {
   home.packages = with pkgs; [
     gh
     ghq
     gitleaks
-    git-clean
+    customPackages.git-tools-bin
   ];
 
   xdg.configFile."git/hooks/pre-commit".source = preCommitHook;

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -11,6 +11,7 @@ rec {
   gemini-cli-workforce = pkgs.callPackage ./gemini-cli-workforce {
     inherit gemini-cli-bin;
   };
+  git-tools-bin = pkgs.callPackage ./git-tools-bin { };
   opencode-bin = pkgs.callPackage ./opencode-bin { };
   opencode-sandboxed = pkgs.callPackage ./opencode-sandboxed {
     inherit opencode-bin;

--- a/packages/git-tools-bin/default.nix
+++ b/packages/git-tools-bin/default.nix
@@ -8,9 +8,9 @@
 #
 # Update workflow: update `version` and `hash` below, then deploy.
 {
-  fetchurl,
   lib,
   stdenvNoCC,
+  fetchurl,
 }:
 let
   version = "20260602-033259";
@@ -34,6 +34,7 @@ stdenvNoCC.mkDerivation {
   meta = {
     description = "Pre-built git-tools binaries (darwin-arm64): Git subcommands generating Conventional Commits messages and branch names, cleaning merged branches, and scanning staged changes for secrets via Apple's on-device model";
     homepage = "https://github.com/usabarashi/git-tools";
+    license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     platforms = [ "aarch64-darwin" ];
   };

--- a/packages/git-tools-bin/default.nix
+++ b/packages/git-tools-bin/default.nix
@@ -1,0 +1,40 @@
+# git-tools native binaries fetched from GitHub Releases, managed independently of nixpkgs.
+#
+# Building from source requires full Xcode (the FoundationModels @Generable macro
+# plugin ships only with Xcode), which a Nix sandbox cannot provide, so the
+# pre-built release archive is used instead.
+#
+# Provides: git-commit-message, git-branch-name, git-branch-clean, git-secret-check
+#
+# Update workflow: update `version` and `hash` below, then deploy.
+{
+  fetchurl,
+  lib,
+  stdenvNoCC,
+}:
+let
+  version = "20260602-033259";
+  src = fetchurl {
+    url = "https://github.com/usabarashi/git-tools/releases/download/build-${version}/git-tools-${version}-macos26-arm64.tar.gz";
+    hash = "sha256-FCXdnSYsKcjn7aHNSF7HQpLChjWDBLy4DltL9NiMOvo=";
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "git-tools-bin";
+  inherit version src;
+  dontBuild = true;
+  dontStrip = true;
+  installPhase = ''
+    runHook preInstall
+    for tool in git-commit-message git-branch-name git-branch-clean git-secret-check; do
+      install -Dm755 "$tool" "$out/bin/$tool"
+    done
+    runHook postInstall
+  '';
+  meta = {
+    description = "Pre-built git-tools binaries (darwin-arm64): Git subcommands generating Conventional Commits messages and branch names, cleaning merged branches, and scanning staged changes for secrets via Apple's on-device model";
+    homepage = "https://github.com/usabarashi/git-tools";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [ "aarch64-darwin" ];
+  };
+}


### PR DESCRIPTION


## Why
The upstream `git-commit-message` project was renamed to `git-tools` and now ships four Git subcommands (commit-message, branch-name, branch-clean, secret-check) as a single release archive instead of a lone binary. The configuration still pointed at the old repository, and a hand-written `git-clean` shell script duplicated functionality the new suite now covers.

## What
- Replaced the single-binary fetch with one package that unpacks the release archive and installs all four subcommands, keeping the binary-from-Releases approach because building from source needs full Xcode (the `@Generable` macro plugin) which the Nix sandbox cannot provide.
- Removed the local `git-clean` script rather than keeping both: the new `git-branch-clean` is a superset (it also handles squash-merged branches), so maintaining a parallel shell implementation only invites drift. The trade-off is a command rename from `git clean` to `git branch-clean`.
- Pinned the package by `version` + SRI `hash` so updates stay an explicit, reviewable two-line change.

## References
N/A
