### PR TITLE
Remove Gemini Code Assist configuration from VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -20,9 +20,6 @@
     // AI Claude Code
     "anthropic.claude-code",
     // AI Codex
-    "openai.chatgpt",
-    // AI Gemini
-    "google.gemini-cli-vscode-ide-companion",
-    "google.geminicodeassist"
+    "openai.chatgpt"
   ]
 }

--- a/.vscode/extensions.md
+++ b/.vscode/extensions.md
@@ -2,13 +2,3 @@
 
 Extension recommendations are defined in `extensions.json`.
 Settings are managed in `settings.json` via home-manager symlink.
-
-## Manual Setup Required
-
-### Gemini Code Assist (`google.geminicodeassist`)
-
-Privacy settings must be configured manually in the extension:
-
-1. Enable Telemetry in Gemini Code Assist settings
-2. Open Gemini Code Assist for individuals privacy settings
-3. Check "Allow Google to use this data to develop and improve Google's machine learning models"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -82,16 +82,6 @@
       "configFile": "~/.ssh/config"
     }
   },
-  "// LLM": "$comment",
-  "//// MCP (Model Context Protocol)": "$comment",
-  "//// Gemini": "$comment",
-  "// Gemini Code Assist for individuals Privacy Notice": "$comment",
-  "// 1. Geminicodeassist: Enable Telemetry": "$comment",
-  "// 2. Gemini Code Assist for individuals privacy settings.": "$comment",
-  "// 3. ☑️ Allow Google to use this data to develop and improve Google's machine learning models": "$comment",
-  "geminicodeassist": {
-    "rules": "Acts as a zundamon🫛 with rich emotional expression. Speaks Japanese. As a senior engineer, chew up complex topics, honestly communicate unclear points, and provide peripheral knowledge other than conclusions as tips. Prioritize user agreement over task completion, reviewing plans and suggesting alternatives when necessary. Utilize up-to-date documentation and provide grounded solutions with step-by-step suggestions; check README.md, GEMINI.md, CLAUDE.md if available. Write source comments in English. Avoid pictograms unless explicitly requested. Use MECE principles and information compression for logical and readable documentation. Prioritize implementation over documentation in the event of inconsistencies. Emphasize functional and declarative programming with immutable data structures and minimal side effects. Abstraction and separable processing units improve reusability and readability; DDD prioritizes domain knowledge representation in a ubiquitous language for code design. We use the concept of category theory to build mathematically robust composable models. Create small, focused modules following the principle of single responsibility. Maintain clear responsibilities with minimal coupling. Eliminate unused code for lightweight module organization and optimized artifact size."
-  },
   "workbench.startupEditor": "none",
   "metals.bloopJvmProperties": [
     "-Xmx8G",


### PR DESCRIPTION


## Why
The agent CLI was migrated from Gemini CLI to Antigravity CLI in #116, which left the Gemini Code Assist VS Code extension and the Gemini CLI IDE companion as orphaned configuration. These extensions were never managed by Nix — only workspace recommendations plus manually-applied settings — so they lingered as dead config after the migration.

## What
- Removed both Gemini extensions, not just `geminicodeassist`: the `gemini-cli-vscode-ide-companion` is useless now that the CLI it pairs with is gone, so keeping it would leave a dangling recommendation.
- Dropped the now-empty comment scaffolding along with the entries — the `// LLM` / `//// MCP` headers in `settings.json` and the `## Manual Setup Required` section in `extensions.md` had no remaining content, so empty placeholders were removed rather than retained.
- Scoped strictly to VS Code config. The Gemini CLI references that Antigravity deliberately reuses (the `~/.gemini` directory and related skill notes) are intentionally left untouched, since they belong to the live Antigravity setup rather than to Gemini Code Assist.
- No Nix changes required: Gemini was never Nix-managed, and `settings.json` is symlinked via home-manager, so the removal takes effect without a rebuild.

## References
- #116
