### PR TITLE
Add chrome-devtools-mcp as a custom package wired to all agents

### DIFF
--- a/config/antigravity/mcp_config.json
+++ b/config/antigravity/mcp_config.json
@@ -3,6 +3,10 @@
     "voicevox": {
       "command": "voicevox-mcp-server",
       "args": []
+    },
+    "chrome-devtools": {
+      "command": "chrome-devtools-mcp",
+      "args": ["--autoConnect", "--channel=stable"]
     }
   }
 }

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -38,3 +38,19 @@ command = "voicevox-mcp-server"
 args = []
 startup_timeout_sec = 20
 tool_timeout_sec = 120
+
+# chrome-devtools-mcp drives the system Google Chrome via puppeteer-core.
+# Provided on PATH by modules/shared/agents-common.nix (Node hidden in the
+# Nix store; only `chrome-devtools-mcp` reaches PATH).
+#
+# --autoConnect attaches to the already-running stable Chrome (Chrome 144+)
+# instead of launching a fresh instance; this avoids the launch crash that
+# happens when the on-disk Chrome was just auto-updated to a newer version
+# than the still-running one. Requires remote debugging enabled in Chrome
+# (chrome://inspect/#remote-debugging).
+[mcp_servers.chrome-devtools]
+type = "stdio"
+command = "chrome-devtools-mcp"
+args = ["--autoConnect", "--channel=stable"]
+startup_timeout_sec = 30
+tool_timeout_sec = 120

--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -14,6 +14,11 @@
       "type": "local",
       "command": ["voicevox-mcp-server"],
       "timeout": 120000
+    },
+    "chrome-devtools": {
+      "type": "local",
+      "command": ["chrome-devtools-mcp", "--autoConnect", "--channel=stable"],
+      "timeout": 120000
     }
   },
   "provider": {

--- a/modules/shared/agents-common.nix
+++ b/modules/shared/agents-common.nix
@@ -1,15 +1,20 @@
 {
+  pkgs,
   flakeInputs,
   ...
 }:
 
 {
-  # voicevox-cli provides `voicevox-mcp-server`, the MCP server referenced by
-  # all four agents (Claude Code, Codex, Antigravity, opencode). Each agents-*.nix
-  # imports this module so the runtime dependency is always present whenever any
-  # agent is active; buildEnv dedups the package by store path, so listing it from
-  # several agents is harmless.
+  # MCP servers referenced by all four agents (Claude Code, Codex, Antigravity,
+  # opencode). Each agents-*.nix imports this module so the runtime dependencies
+  # are always present whenever any agent is active; buildEnv dedups packages by
+  # store path, so listing them from several agents is harmless.
+  #
+  # - voicevox-cli provides `voicevox-mcp-server`.
+  # - chrome-devtools-mcp provides `chrome-devtools-mcp` (Node hidden in the Nix
+  #   store; only this command reaches PATH). Drives the system Google Chrome.
   home.packages = [
     flakeInputs.voicevox-cli
+    pkgs.customPackages.chrome-devtools-mcp
   ];
 }

--- a/packages/chrome-devtools-mcp/default.nix
+++ b/packages/chrome-devtools-mcp/default.nix
@@ -27,8 +27,8 @@
   lib,
   stdenvNoCC,
   fetchurl,
-  makeWrapper,
   nodejs_22,
+  makeWrapper,
 }:
 let
   version = "1.1.1";

--- a/packages/chrome-devtools-mcp/default.nix
+++ b/packages/chrome-devtools-mcp/default.nix
@@ -1,0 +1,79 @@
+# chrome-devtools-mcp: Google's MCP server for Chrome DevTools, fetched as the
+# pre-built npm tarball and wrapped with a pinned Node runtime.
+#
+# The published npm package is fully bundled by rollup: package.json declares no
+# `dependencies` and the tarball ships no `node_modules` (puppeteer-core,
+# lighthouse, the MCP SDK, etc. are all inlined into `build/`). So there is
+# nothing to resolve at build time -- this follows the repo's `*-bin` convention
+# (fixed upstream artifact + fixed hash + wrapper) rather than buildNpmPackage.
+#
+# Node is required at runtime but never reaches the user's PATH: the wrapper
+# invokes `${nodejs_22}/bin/node` from the Nix store and only `chrome-devtools-mcp`
+# is exposed in $out/bin.
+#
+# The whole package root (package.json + build/) is installed, not just build/:
+# the entrypoint is ESM by virtue of package.json's `"type": "module"`, so the
+# manifest must remain in an ancestor directory or Node would treat the `.js`
+# entrypoint as CommonJS and fail on the first `import`.
+#
+# Runtime browser: drives the system-installed Google Chrome, auto-detected by
+# puppeteer-core (no Chrome bundled here). If detection ever fails, point it at
+# `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` via the
+# server's --executablePath flag or PUPPETEER_EXECUTABLE_PATH.
+#
+# Update workflow: bump `version`, then update `hash` (the build fails printing
+# the correct SRI hash on mismatch), then deploy.
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeWrapper,
+  nodejs_22,
+}:
+let
+  version = "1.1.1";
+  src = fetchurl {
+    url = "https://registry.npmjs.org/chrome-devtools-mcp/-/chrome-devtools-mcp-${version}.tgz";
+    hash = "sha256-dljKBMgor370c16Dsp6ATFox0xCOiaeHLGo5EpNV8QQ=";
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "chrome-devtools-mcp";
+  inherit version src;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # npm tarballs unpack into a top-level `package/` directory.
+  sourceRoot = "package";
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/lib/chrome-devtools-mcp"
+    cp -R package.json build "$out/lib/chrome-devtools-mcp/"
+    install -Dm644 LICENSE "$out/share/doc/chrome-devtools-mcp/LICENSE"
+
+    makeWrapper "${nodejs_22}/bin/node" "$out/bin/chrome-devtools-mcp" \
+      --add-flags "$out/lib/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    "$out/bin/chrome-devtools-mcp" --help > /dev/null
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "MCP server that exposes Chrome DevTools (via puppeteer-core) to MCP clients; wraps the pre-bundled npm release with a pinned Node runtime";
+    homepage = "https://github.com/ChromeDevTools/chrome-devtools-mcp";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    mainProgram = "chrome-devtools-mcp";
+    platforms = [ "aarch64-darwin" ];
+  };
+}

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -2,6 +2,7 @@
 
 rec {
   antigravity-cli-bin = pkgs.callPackage ./antigravity-cli-bin { };
+  chrome-devtools-mcp = pkgs.callPackage ./chrome-devtools-mcp { };
   claude-code-bin = pkgs.callPackage ./claude-code-bin { };
   claude-code-sandboxed = pkgs.callPackage ./claude-code-sandboxed {
     inherit claude-code-bin;


### PR DESCRIPTION


## Why
chrome-devtools-mcp is not in nixpkgs, and the upstream-recommended `npx chrome-devtools-mcp@latest` both requires node/npx on PATH and pulls an unpinned runtime every invocation. The goal was to make the server available to every MCP client without exposing a Node toolchain in the user environment and without a mutable `@latest` dependency.

## What
- Package the pre-bundled npm tarball via `fetchurl` + a Node wrapper (the repo's existing `*-bin` convention) rather than `buildNpmPackage`. The published tarball is fully rollup-bundled — no `dependencies`, no `node_modules` — so `buildNpmPackage` would only add lockfile/npmDeps machinery with no reproducibility gain.
- Keep Node entirely inside the Nix store and expose only `chrome-devtools-mcp` on PATH, satisfying the "no node/npx installed" requirement (same model as `claude-code-bin`).
- Install the whole package root, not just `build/`, so `package.json`'s `"type": "module"` stays in an ancestor directory; otherwise Node treats the `.js` entrypoint as CommonJS and the first `import` fails.
- Pin exact version + SRI hash for immutability and integrity. The pinned bytes were verified against npm's published sha512/sha1 and against the package's SLSA provenance attestation (built by GitHub Actions from the ChromeDevTools/chrome-devtools-mcp repo).
- Register the server for Codex, Antigravity, and opencode by bare command name (resolved via the shared `agents-common.nix` PATH entry, mirroring how voicevox is wired). Claude Code's MCP wiring stays manual in `~/.claude.json`, consistent with how serena is already handled there, so it is intentionally not Nix-managed.
- Pass `--autoConnect --channel=stable` so the server attaches to the already-running stable Chrome instead of launching a fresh instance, which avoids a launch crash observed when the on-disk Chrome had been auto-updated ahead of the running one. Pinned `nodejs_22` (LTS) as the runtime.

## References
N/A
