### PR TITLE
Isolate chrome-devtools-mcp browser sessions and opt out of telemetry

### DIFF
--- a/config/antigravity/mcp_config.json
+++ b/config/antigravity/mcp_config.json
@@ -6,7 +6,7 @@
     },
     "chrome-devtools": {
       "command": "chrome-devtools-mcp",
-      "args": ["--autoConnect", "--channel=stable"]
+      "args": ["--isolated", "--headless", "--channel=stable", "--no-usage-statistics", "--no-performance-crux", "--chromeArg=--no-sandbox"]
     }
   }
 }

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -39,18 +39,16 @@ args = []
 startup_timeout_sec = 20
 tool_timeout_sec = 120
 
-# chrome-devtools-mcp drives the system Google Chrome via puppeteer-core.
-# Provided on PATH by modules/shared/agents-common.nix (Node hidden in the
-# Nix store; only `chrome-devtools-mcp` reaches PATH).
-#
-# --autoConnect attaches to the already-running stable Chrome (Chrome 144+)
-# instead of launching a fresh instance; this avoids the launch crash that
-# happens when the on-disk Chrome was just auto-updated to a newer version
-# than the still-running one. Requires remote debugging enabled in Chrome
-# (chrome://inspect/#remote-debugging).
+# chrome-devtools-mcp drives Google Chrome via puppeteer-core; on PATH via
+# modules/shared/agents-common.nix. Flags (non-obvious reasons only):
+# - --isolated: ephemeral profile, never attaches to the real logged-in Chrome.
+# - --headless: avoids the singleton crash when the user's Chrome is running.
+# - --chromeArg=--no-sandbox: required here, else Chrome's sandbox init fails
+#   ("Operation not permitted") and every tool call times out.
+# - --no-usage-statistics / --no-performance-crux: opt out of Google telemetry.
 [mcp_servers.chrome-devtools]
 type = "stdio"
 command = "chrome-devtools-mcp"
-args = ["--autoConnect", "--channel=stable"]
+args = ["--isolated", "--headless", "--channel=stable", "--no-usage-statistics", "--no-performance-crux", "--chromeArg=--no-sandbox"]
 startup_timeout_sec = 30
 tool_timeout_sec = 120

--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -17,7 +17,7 @@
     },
     "chrome-devtools": {
       "type": "local",
-      "command": ["chrome-devtools-mcp", "--autoConnect", "--channel=stable"],
+      "command": ["chrome-devtools-mcp", "--isolated", "--headless", "--channel=stable", "--no-usage-statistics", "--no-performance-crux", "--chromeArg=--no-sandbox"],
       "timeout": 120000
     }
   },


### PR DESCRIPTION


## Why
chrome-devtools-mcp was wired with `--autoConnect`, which attaches the agents to the user's real, already-running Chrome over CDP. That gave every agent (and any prompt-injection payload on a page the agent reads) full access to all authenticated browser sessions — cookies, tokens, and localStorage for Gmail, banking, enterprise SaaS, etc. The server also sent usage telemetry to Google by default, independent of each agent's own telemetry settings.

## What
- Replaced `--autoConnect` with `--isolated`, so each run gets a throwaway profile and never touches the real logged-in Chrome. This removes the session-exfiltration and hijack surface at the root: there are no standing logins to steal. Rejected keeping the main profile behind operational rules (relies on human discipline) and a persistent dedicated `--userDataDir` (re-introduces standing sessions).
- Added `--headless` because relaunching an isolated *headed* Chrome crashes on the macOS app-singleton conflict while the user's Chrome is running — the exact failure `--autoConnect` had been masking. Headless runs detached and starts cleanly. Trade-off: no interactive human login, which is acceptable for agent-driven automation.
- Added `--chromeArg=--no-sandbox` because this machine launches Chrome as a subprocess under a parent seatbelt, so Chrome's own renderer sandbox init fails with "Operation not permitted" and the server never finishes starting. This does not re-open the session-exfil path (`--isolated` already removed the high-value sessions); the residual risk is a renderer exploit escaping to the host, which requires both a Chrome RenderProcess vulnerability and the agent visiting a malicious page.
- Added `--no-usage-statistics` and `--no-performance-crux` to stop the Clearcut usage-stats and CrUX trace-URL submissions the MCP subprocess sends by default.
- Applied the same flag set uniformly across all repo-managed agents (codex, antigravity, opencode) to keep their browser posture identical, and trimmed the codex comment to the non-obvious rationale only.

## References
- #119
