### PR TITLE
Scope chrome-devtools --no-sandbox to Seatbelt-sandboxed agents

### DIFF
--- a/config/antigravity/mcp_config.json
+++ b/config/antigravity/mcp_config.json
@@ -6,7 +6,7 @@
     },
     "chrome-devtools": {
       "command": "chrome-devtools-mcp",
-      "args": ["--isolated", "--headless", "--channel=stable", "--no-usage-statistics", "--no-performance-crux", "--chromeArg=--no-sandbox"]
+      "args": ["--isolated", "--headless", "--channel=stable", "--no-usage-statistics", "--no-performance-crux"]
     }
   }
 }

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -43,12 +43,10 @@ tool_timeout_sec = 120
 # modules/shared/agents-common.nix. Flags (non-obvious reasons only):
 # - --isolated: ephemeral profile, never attaches to the real logged-in Chrome.
 # - --headless: avoids the singleton crash when the user's Chrome is running.
-# - --chromeArg=--no-sandbox: required here, else Chrome's sandbox init fails
-#   ("Operation not permitted") and every tool call times out.
 # - --no-usage-statistics / --no-performance-crux: opt out of Google telemetry.
 [mcp_servers.chrome-devtools]
 type = "stdio"
 command = "chrome-devtools-mcp"
-args = ["--isolated", "--headless", "--channel=stable", "--no-usage-statistics", "--no-performance-crux", "--chromeArg=--no-sandbox"]
+args = ["--isolated", "--headless", "--channel=stable", "--no-usage-statistics", "--no-performance-crux"]
 startup_timeout_sec = 30
 tool_timeout_sec = 120


### PR DESCRIPTION


## Why
Commit 962f1d6 added `--chromeArg=--no-sandbox` uniformly to every agent's chrome-devtools-mcp config to work around Chrome's renderer sandbox failing to initialize ("Operation not permitted") under the macOS Seatbelt that wraps the sandboxed agents. Applied uniformly, the flag also reached codex and antigravity, which run as raw binaries with no Seatbelt — there it stripped Chrome's OS-level renderer sandbox for no functional reason, leaving the renderer fully unprotected against a renderer exploit (e.g. CVE-2026-8018). Flagged by the security audit as B-1.

## What
- Scope the flag to where it is actually required rather than carrying it everywhere. codex and antigravity have no outer Seatbelt, so Chrome's native renderer sandbox initializes normally; dropping the flag restores OS-level renderer protection at zero functional cost (verified the browser still drives a fresh `--isolated` context, not the user profile).
- Leave opencode untouched: it runs under Seatbelt, which blocks Chrome's sandbox syscalls, so the flag is a genuine requirement there. Its residual renderer risk is contained by Seatbelt's write-confinement plus the `--isolated --headless` empty profile, and is accepted.
- Rejected removing the flag globally (breaks the Seatbelt-wrapped agent) and suppressing the finding as accepted risk (leaves codex/antigravity needlessly exposed).

## References
- #120
