### PR TITLE
Bump AI agent packages and serena to current releases

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -251,11 +251,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1779881517,
-        "narHash": "sha256-mgC2rUVlBRHP+OFMW8BiWNXq13eqWMjoLBt2jP9dJXU=",
+        "lastModified": 1780928201,
+        "narHash": "sha256-+LhqW3zbSfEhdyLNbi9XO9DLL3wyCyKCYYCAXE5fmVA=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "7bf30080f6aa8fc1f983e1d72bc91dd790f28d29",
+        "rev": "4385741e8cc63fa67fe97c3a75121611bce1eb26",
         "type": "github"
       },
       "original": {

--- a/packages/antigravity-cli-bin/default.nix
+++ b/packages/antigravity-cli-bin/default.nix
@@ -11,8 +11,11 @@
 # Pinned here so `agy update` cannot drift the store path out from under Nix.
 let
   version = "1.0.6";
+  # GCS build ID appended to the version in the bucket path; published alongside
+  # `version` in the auto-updater manifest and bumped together with it.
+  buildId = "6458082025406464";
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.6-6458082025406464/darwin-arm/cli_mac_arm64.tar.gz";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${version}-${buildId}/darwin-arm/cli_mac_arm64.tar.gz";
     hash = "sha512-3k/XXkeDPPHxRYu492NI49zD+GKjvGHxgb+MRNlQPImAy2m2hxUfgOIveaVc/AfqeUq1T2ZY2XqsKzk6OCKiuw==";
   };
 in

--- a/packages/antigravity-cli-bin/default.nix
+++ b/packages/antigravity-cli-bin/default.nix
@@ -10,10 +10,10 @@
 # https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/darwin_arm64.json
 # Pinned here so `agy update` cannot drift the store path out from under Nix.
 let
-  version = "1.0.4";
+  version = "1.0.6";
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.4-6410134369468416/darwin-arm/cli_mac_arm64.tar.gz";
-    hash = "sha512-f3LIox2jBBEUaPQwI+PGEbmxA1lVqRVeX8D6dwgwl24qI3heFfAwQYMbBE/vLuwjvb+iOUs59s1UHZ5EnaHH2w==";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.6-6458082025406464/darwin-arm/cli_mac_arm64.tar.gz";
+    hash = "sha512-3k/XXkeDPPHxRYu492NI49zD+GKjvGHxgb+MRNlQPImAy2m2hxUfgOIveaVc/AfqeUq1T2ZY2XqsKzk6OCKiuw==";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/chrome-devtools-mcp/default.nix
+++ b/packages/chrome-devtools-mcp/default.nix
@@ -31,10 +31,10 @@
   makeWrapper,
 }:
 let
-  version = "1.1.1";
+  version = "1.2.0";
   src = fetchurl {
     url = "https://registry.npmjs.org/chrome-devtools-mcp/-/chrome-devtools-mcp-${version}.tgz";
-    hash = "sha256-dljKBMgor370c16Dsp6ATFox0xCOiaeHLGo5EpNV8QQ=";
+    hash = "sha256-r2qGlCRLSzDbSAM8sOClDBO7cIZkSEcJn571zHYgigU=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/claude-code-bin/default.nix
+++ b/packages/claude-code-bin/default.nix
@@ -7,10 +7,10 @@
   stdenvNoCC,
 }:
 let
-  version = "2.1.158";
+  version = "2.1.169";
   src = fetchurl {
     url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${version}/darwin-arm64/claude";
-    hash = "sha256-U2oFF/pk1I3cvI61EaPQgCfUfgbRSIcjMqgEHXLCJ2g=";
+    hash = "sha256-hti4IK1+7VDlChMHBtPcXvcGlvkRlN4bOJeoQhgq/jo=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/codex-bin/default.nix
+++ b/packages/codex-bin/default.nix
@@ -7,11 +7,11 @@
   stdenvNoCC,
 }:
 let
-  version = "0.134.0";
+  version = "0.138.0";
   asset = "codex-aarch64-apple-darwin";
   src = fetchurl {
     url = "https://github.com/openai/codex/releases/download/rust-v${version}/${asset}.tar.gz";
-    hash = "sha256-eK1ILMrrDriYOzQPM6HyjIrTFbbV4xQMNMfhGcgmvBI=";
+    hash = "sha256-zDnBXPL4um1k5DiaYAIAxVTeqnTznrpJ5NvLL3U/SkU=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/opencode-bin/default.nix
+++ b/packages/opencode-bin/default.nix
@@ -9,11 +9,11 @@
   unzip,
 }:
 let
-  version = "1.15.12";
+  version = "1.16.2";
   asset = "opencode-darwin-arm64";
   src = fetchurl {
     url = "https://github.com/sst/opencode/releases/download/v${version}/${asset}.zip";
-    hash = "sha256-1lTw4/Ur26VgsarAIeH+x+9FbSGw8Cw7qCAoQ+c9vUU=";
+    hash = "sha256-AVhf9NFYIL06h45Lx8rPsep14jbR/tjC9fNZXtyLerU=";
   };
 in
 stdenvNoCC.mkDerivation {


### PR DESCRIPTION


## Why
Each AI CLI/MCP binary (claude-code, codex, antigravity, opencode, chrome-devtools-mcp) and the serena input are deliberately pinned to a fixed version + hash so vendor auto-updaters cannot drift the Nix store path. Those pins had fallen several releases behind upstream — a daily security audit flagged chrome-devtools-mcp v1.1.1 trailing v1.2.0, and the coding agents were stale enough to miss recent vendor hardening for the SymJack/TrustFall approval-dialog vulnerabilities.

## What
- Refreshed all five pinned binaries to their current upstream releases and advanced the serena flake input; every SRI hash was recomputed with `nix store prefetch-file` rather than copied from upstream notes.
- Kept the existing per-package fetch convention (explicit version + pinned hash, no live auto-update) instead of moving to unpinned sources or nixpkgs, preserving reproducibility and keeping `agy update`/npm from mutating the store path out from under Nix.
- antigravity retains its manifest-published sha512 rather than being converted to sha256, staying faithful to the upstream auto-updater provenance.
- Validated with a full `nix build` of the mac14-9 system (all hashes resolve; chrome-devtools-mcp `--help` install-check passes) and `nix fmt -- --fail-on-change`.

## References
N/A
