### PR TITLE
Refresh AI stack: gemma-4 local LLM + CLI bumps

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -261,6 +261,7 @@
     "enabled": false,
     "mode": "hold"
   },
+  "skipAutoPermissionPrompt": true,
   "voiceEnabled": false,
-  "skipAutoPermissionPrompt": true
+  "model": "claude-opus-4-7"
 }

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -10,9 +10,10 @@ model_verbosity = "medium"
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"
 web_search = "live"
-notify = ["bash", "-lc", "afplay /System/Library/Sounds/Ping.aiff"]
 personality = "pragmatic"
 project_doc_fallback_filenames = ["CLAUDE.md", "GEMINI.md"]
+
+notify = ["bash", "-lc", "afplay /System/Library/Sounds/Ping.aiff"]
 
 # Features
 [features]

--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -39,8 +39,8 @@
         "baseURL": "http://127.0.0.1:8080/v1"
       },
       "models": {
-        "qwen3.6-35b-a3b": {
-          "name": "Qwen3.6 35B-A3B MoE UD-IQ4_XS (local)",
+        "gemma-4-26b-a4b": {
+          "name": "Gemma 4 26B-A4B MoE QAT Q4_K_XL (local)",
           "tool_call": true,
           "reasoning": true,
           "limit": {
@@ -72,7 +72,7 @@
     "review": {
       "description": "Read-only code reviewer. Inspect the current git diff first, then read touched files as needed. Flag correctness risks, regressions, security issues, and missing tests. Do not edit files.",
       "mode": "subagent",
-      "model": "opencode-go/kimi-k2.6",
+      "model": "opencode-go/kimi-k2.7-code",
       "steps": 8,
       "temperature": 0.1,
       "permission": {

--- a/flake.lock
+++ b/flake.lock
@@ -98,11 +98,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779726696,
-        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
+        "lastModified": 1781533608,
+        "narHash": "sha256-Mgsu/x5cs8EqlhIQ7bMBo14LpkAYtgzDbG/S/eattJA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
+        "rev": "8aec76cc1e045f37b55d82ca3cee4910ae04d3db",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779036909,
-        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "lastModified": 1781242433,
+        "narHash": "sha256-bchLZZ3sRn740zyvD2icZSnNoTaanN0nw7l6fjVXO+E=",
         "ref": "refs/heads/master",
-        "rev": "56c666e108467d87d13508936aade6d567f2a501",
-        "revCount": 2360,
+        "rev": "aabb2037edfc0f210723b72cd5f528aab5dd3f0b",
+        "revCount": 2379,
         "type": "git",
         "url": "https://github.com/nix-darwin/nix-darwin"
       },
@@ -133,11 +133,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779694939,
-        "narHash": "sha256-Ly4j75O8ICaSQx3uxPnwk2x7PMF0XQvn5r0c3yBA7FI=",
+        "lastModified": 1781454065,
+        "narHash": "sha256-d2xfDjnfRuf/xYGdu9VVRHiav/2w5hDL/5cw2TuVAXw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f9d8b65950353691ab56561e7c73d2e1063d810b",
+        "rev": "9eac87a12312b8f60dd52e1c6e1a265f6fc7f5fc",
         "type": "github"
       },
       "original": {
@@ -251,11 +251,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1779881517,
-        "narHash": "sha256-mgC2rUVlBRHP+OFMW8BiWNXq13eqWMjoLBt2jP9dJXU=",
+        "lastModified": 1781518176,
+        "narHash": "sha256-Jle852Ag7NPG5sE+FbRk3wqkWIHUPDIgZPcCo9ssSIQ=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "7bf30080f6aa8fc1f983e1d72bc91dd790f28d29",
+        "rev": "652a739826b9f54a0161fd2cf385c3259db24f32",
         "type": "github"
       },
       "original": {

--- a/modules/shared/llm.nix
+++ b/modules/shared/llm.nix
@@ -78,11 +78,33 @@
     # `--slot-save-path` only exposes /slots/X?action=save|restore — prefix
     # caches must be persisted explicitly, not on shutdown.
     #
-    # No MTP head: gemma-4 does not ship multi-token-prediction weights, so
-    # `--spec-type draft-mtp` is removed. A draft-model speculative path
-    # (e.g. gemma-4-E2B via `--model-draft`) is possible but A4B's 3.8B
-    # active decode is already fast enough for OpenCode interactive use on
-    # M2 Pro; revisit if long-form generation feels slow.
+    # Speculative decoding intentionally disabled. An external gemma-4-E2B
+    # draft was measured at ~42% acceptance with `--spec-draft-n-max 4` on
+    # this hardware, yielding ~17 t/s decode vs ~46 t/s baseline — the
+    # draft inference cost and verify overhead outweighed the gain. The
+    # E2B and 26B-A4B share family/tokenizer/template but are trained
+    # independently, so they lack the in-model agreement that MTP-style
+    # heads (e.g. Qwen3.6's bundled MTP) provide. Revisit only with a
+    # same-family trained spec head (MTP / EAGLE-3 variant) or a
+    # benchmarked draft config that demonstrably beats baseline.
+    #
+    # Reasoning controls: gemma-4 has interleaved thinking. `-rea on`
+    # forces thinking on (vs. model-default auto, the only non-default
+    # here). `--reasoning-format auto` keeps the default extraction mode
+    # explicit; when the model emits recognized thought tags they are
+    # separated into the API `reasoning_content` field (vs. mixed into
+    # `content`), which lets OpenCode fold them in its UI.
+    # `--reasoning-budget 4096` caps per-turn thinking tokens to bound
+    # latency on simple queries — unrestricted (-1) lets the model run
+    # away on trivial questions before producing visible output.
+    #
+    # `--cache-ram 4096` caps the host-memory prompt cache below its
+    # 8192 MiB default to leave ~4 GiB of system headroom on this 32 GiB
+    # machine. This is distinct from KV cache (sized by `-c` and
+    # `--cache-type-*`); gemma-4's SWA already keeps KV modest, and the
+    # prompt cache itself rarely needs the full 8 GiB for interactive
+    # use. If OpenCode begins reprocessing large repeated prefixes (long
+    # agentic sessions), this is the first knob to raise back to 8192.
     #
     # Sampling defaults follow the gemma-4 model card (temp=1.0, top_p=0.95,
     # top_k=64) — these differ markedly from Qwen3 conventions, in particular
@@ -113,8 +135,16 @@
           "q8_0"
           "--cache-reuse"
           "256"
+          "--cache-ram"
+          "4096"
           "--slot-save-path"
           "${homeDirectory}/.cache/llama-server-slots"
+          "-rea"
+          "on"
+          "--reasoning-format"
+          "auto"
+          "--reasoning-budget"
+          "4096"
           "--host"
           "127.0.0.1"
           "--port"

--- a/modules/shared/llm.nix
+++ b/modules/shared/llm.nix
@@ -62,35 +62,31 @@
       };
     };
 
-    # llama-server hosts Qwen3.6-35B-A3B (MoE, 3B active) for OpenCode.
-    # On-demand because the 22 GiB resident model would otherwise pin unified
-    # memory; SwiftBar plugin (config/swiftbar/) exposes menu-bar Start/Stop.
-    # Sparse attention (full_attention_interval=4, 10/40 layers full) keeps
-    # q8 KV at 64k under ~700 MiB on Metal. `--flash-attn on` is required
-    # with quantized KV, else dequantize round-trips erase the savings.
-    # `--no-mmproj` skips the bundled vision projector. `--slot-save-path`
-    # only exposes /slots/X?action=save|restore — prefix caches must be
-    # persisted explicitly, not on shutdown.
+    # llama-server hosts Gemma 4 26B-A4B (MoE, 3.8B active) QAT for OpenCode.
+    # On-demand via SwiftBar plugin (config/swiftbar/) to keep unified memory
+    # free when idle. QAT (quantization-aware training) preserves bf16-class
+    # quality at Q4 memory, so the Q4_K_XL file (~14.2 GiB on disk) is the
+    # recommended quant — plain Q4 quants of the same model carry a measurable
+    # accuracy hit that QAT trains out.
     #
-    # MTP (Multi Token Prediction) speculative decoding via `--spec-type
-    # draft-mtp` (llama.cpp b9190+, PR ggml-org/llama.cpp#22673). The MTP
-    # head loads from the same GGUF but llama.cpp allocates it as a separate
-    # model with its own context/KV; recurrent-state rollback landed in the
-    # same PR, which is what makes this viable for Qwen3.6's Mamba/SSM
-    # layers. Memory delta is NOT free: the extra KV alone is ~67 MiB
-    # (1 MTP layer at 65k q8), but PR user data shows a Qwen3.6-27B Q6 run
-    # going from 22.47 -> 24.96 GiB (+2.49 GiB) with MTP enabled, attributed
-    # to the second-context allocation plus runtime buffers. Treat resident
-    # memory as the gating signal, not theoretical KV math.
+    # Sliding-window attention (1024-token window across most layers) keeps
+    # q8 KV growth modest even at 65k context — substantially smaller than
+    # a dense full-attention model of the same parameter count. `--flash-attn
+    # on` is still required with quantized KV, else dequantize round-trips
+    # erase the savings. `--no-mmproj` skips the bundled vision projector
+    # (gemma-4 ships multimodal variants; OpenCode is text-only).
+    # `--slot-save-path` only exposes /slots/X?action=save|restore — prefix
+    # caches must be persisted explicitly, not on shutdown.
     #
-    # `--spec-draft-n-max 2` chosen for Apple Silicon UMA: PR's Strix Point
-    # APU sweep (closest UMA analog) shows n=2 -> 1.199x, n=3 -> 1.153x.
-    # MoE A3B's already-cheap baseline decode amortizes MTP less than dense
-    # models do, and deeper drafts add verification cost on UMA. Note:
-    # parallel decoding with MTP is "not fully optimized" per the PR, so
-    # OpenCode-subagent concurrent calls may not see single-stream gains.
-    # Prompt processing takes a hit (D2H embedding transfers); watch long
-    # prefills.
+    # No MTP head: gemma-4 does not ship multi-token-prediction weights, so
+    # `--spec-type draft-mtp` is removed. A draft-model speculative path
+    # (e.g. gemma-4-E2B via `--model-draft`) is possible but A4B's 3.8B
+    # active decode is already fast enough for OpenCode interactive use on
+    # M2 Pro; revisit if long-form generation feels slow.
+    #
+    # Sampling defaults follow the gemma-4 model card (temp=1.0, top_p=0.95,
+    # top_k=64) — these differ markedly from Qwen3 conventions, in particular
+    # presence_penalty is unset (gemma is sensitive to repetition penalties).
     llama-server = {
       enable = true;
       config = {
@@ -100,21 +96,11 @@
           # `exec`s its arguments. See `config/llama-server/wrapper.sh`.
           "${homeDirectory}/.config/llama-server/wrapper.sh"
           "${pkgs.llama-cpp}/bin/llama-server"
-          # unsloth MTP GGUF: contains both the base model and the MTP head
-          # in one file. UD-IQ4_XS matches the prior bartowski IQ4_XS quant
-          # in resident size (~18 GiB). The earlier Xet-OID regression that
-          # forced the bartowski mirror was resolved upstream on HF; if it
-          # returns, the symptom is `get_repo_files` reporting "no GGUF
-          # files found" and the fix is either a mirror or a direct URL.
           "-hf"
-          "unsloth/Qwen3.6-35B-A3B-MTP-GGUF:UD-IQ4_XS"
-          "--spec-type"
-          "draft-mtp"
-          "--spec-draft-n-max"
-          "2"
+          "unsloth/gemma-4-26B-A4B-it-qat-GGUF:Q4_K_XL"
           "--no-mmproj"
           "--alias"
-          "qwen3.6-35b-a3b"
+          "gemma-4-26b-a4b"
           "-c"
           "65536"
           "-ngl"
@@ -134,13 +120,11 @@
           "--port"
           "8080"
           "--temp"
-          "0.6"
+          "1.0"
           "--top-p"
           "0.95"
           "--top-k"
-          "20"
-          "--presence-penalty"
-          "1.5"
+          "64"
           "--min-p"
           "0.00"
           "--jinja"

--- a/packages/antigravity-cli-bin/default.nix
+++ b/packages/antigravity-cli-bin/default.nix
@@ -10,10 +10,10 @@
 # https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/darwin_arm64.json
 # Pinned here so `agy update` cannot drift the store path out from under Nix.
 let
-  version = "1.0.4";
+  version = "1.0.8";
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.4-6410134369468416/darwin-arm/cli_mac_arm64.tar.gz";
-    hash = "sha512-f3LIox2jBBEUaPQwI+PGEbmxA1lVqRVeX8D6dwgwl24qI3heFfAwQYMbBE/vLuwjvb+iOUs59s1UHZ5EnaHH2w==";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.8-5963827121094656/darwin-arm/cli_mac_arm64.tar.gz";
+    hash = "sha512-j8ZX7qOhPAZixhS6QFHwQFDLCrunVVUYqts22I2n070hKuTMbPQ5IDiyFlaJaXmuqzL4vwXIDmn8cgx2UQNGNg==";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/chrome-devtools-mcp/default.nix
+++ b/packages/chrome-devtools-mcp/default.nix
@@ -31,10 +31,10 @@
   makeWrapper,
 }:
 let
-  version = "1.1.1";
+  version = "1.2.0";
   src = fetchurl {
     url = "https://registry.npmjs.org/chrome-devtools-mcp/-/chrome-devtools-mcp-${version}.tgz";
-    hash = "sha256-dljKBMgor370c16Dsp6ATFox0xCOiaeHLGo5EpNV8QQ=";
+    hash = "sha256-r2qGlCRLSzDbSAM8sOClDBO7cIZkSEcJn571zHYgigU=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/claude-code-bin/default.nix
+++ b/packages/claude-code-bin/default.nix
@@ -7,10 +7,10 @@
   stdenvNoCC,
 }:
 let
-  version = "2.1.158";
+  version = "2.1.177";
   src = fetchurl {
     url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${version}/darwin-arm64/claude";
-    hash = "sha256-U2oFF/pk1I3cvI61EaPQgCfUfgbRSIcjMqgEHXLCJ2g=";
+    hash = "sha256-6wcwNRvi8CtIKxhVhw9Yd0iQharIawxMHbTkWNnkDtk=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/codex-bin/default.nix
+++ b/packages/codex-bin/default.nix
@@ -7,11 +7,11 @@
   stdenvNoCC,
 }:
 let
-  version = "0.134.0";
+  version = "0.139.0";
   asset = "codex-aarch64-apple-darwin";
   src = fetchurl {
     url = "https://github.com/openai/codex/releases/download/rust-v${version}/${asset}.tar.gz";
-    hash = "sha256-eK1ILMrrDriYOzQPM6HyjIrTFbbV4xQMNMfhGcgmvBI=";
+    hash = "sha256-woNEJVhE2DpyjAhMLZ4h4Wi10hf2BJ06mjaCeQPxb9s=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/git-tools-bin/default.nix
+++ b/packages/git-tools-bin/default.nix
@@ -13,10 +13,10 @@
   fetchurl,
 }:
 let
-  version = "20260602-033259";
+  version = "20260602-164317";
   src = fetchurl {
     url = "https://github.com/usabarashi/git-tools/releases/download/build-${version}/git-tools-${version}-macos26-arm64.tar.gz";
-    hash = "sha256-FCXdnSYsKcjn7aHNSF7HQpLChjWDBLy4DltL9NiMOvo=";
+    hash = "sha256-y4JLczwRLLhEbRNpFcuPfbVU8jc0nukgIXmit4HSKg0=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/opencode-bin/default.nix
+++ b/packages/opencode-bin/default.nix
@@ -9,11 +9,11 @@
   unzip,
 }:
 let
-  version = "1.15.12";
+  version = "1.17.7";
   asset = "opencode-darwin-arm64";
   src = fetchurl {
     url = "https://github.com/sst/opencode/releases/download/v${version}/${asset}.zip";
-    hash = "sha256-1lTw4/Ur26VgsarAIeH+x+9FbSGw8Cw7qCAoQ+c9vUU=";
+    hash = "sha256-emOutaFbKdomgawrjHTUyzpk+hO2EZijx9x3EkPCOXI=";
   };
 in
 stdenvNoCC.mkDerivation {


### PR DESCRIPTION


## Why
The local LLM (Qwen3.6-35B-A3B-MTP) was approaching ~22 GiB resident on a 32 GiB machine and topped out around 6-7 t/s decode even with MTP speculative decoding, leaving little headroom for the editor / browser / OS while OpenCode was active. The host's AI CLI fleet (claude-code-bin, codex-bin, opencode-bin, antigravity-cli-bin, chrome-devtools-mcp) had also drifted several patch / minor releases behind upstream, and the bundled `config/codex/config.toml` had accumulated machine-specific paths injected by the Codex desktop app that needed scrubbing before they could leak into a commit.

## What
- Local model: evaluated alternatives (Qwen3.6-27B-MTP, gemma-4-26B-A4B QAT, North-Mini-Code) and picked **gemma-4-26B-A4B-it-qat (Q4_K_XL, ~14.2 GiB)**. QAT preserves bf16-class quality at Q4 footprint, the MoE 3.8B active path keeps decode cheap, and llama.cpp Metal support is mature for the gemma family. Trade-off accepted: no bundled MTP head, so the prior speculative path doesn't carry over.
- Speculative decoding: tried external `gemma-4-E2B-it-qat` as a draft model with `--spec-draft-n-max 4`. Measured 42% acceptance and 17 t/s decode vs 39 t/s baseline (net loss because draft inference + verify overhead exceeded the gain on UMA). Disabled rather than ship a pessimization; the comment block records the measurement and revisit condition (same-family trained spec head, or a benchmarked draft config that demonstrably beats baseline).
- llama.cpp tuning surfaced by the bundled b9190 → b9503 bump: enabled `-rea on` to force thinking, set `--reasoning-budget 4096` to bound latency on simple queries, kept `--reasoning-format auto` explicit so thoughts route to `reasoning_content`, and capped `--cache-ram` at 4096 MiB to leave ~4 GiB of system headroom. Sampling defaults re-tuned to the gemma-4 model card (`temp=1.0`, `top-k=64`, presence-penalty dropped — gemma is sensitive to repetition penalties).
- AI CLI fleet: routine version bumps with no behavioral changes that affect this repo's wiring. Each package keeps its existing `fetchurl`-based pattern; only `version` and `hash` (and antigravity's URL build hash) move.
- OpenCode review agent: `kimi-k2.6` → `kimi-k2.7-code` (newer code-specialized variant). Primary, math, and small_model slots already current and left alone.
- Codex config: removed Codex-app injected absolute `/Users/gen/...` paths under `[mcp_servers.node_repl]`, `[marketplaces.*]`, `[plugins.*]`, `[projects.*]`, `[tui.*]`, and restored the `notify` line to its repo-shipped form.
- Reviewed via Codex CLI second-opinion pass; confirmed flag correctness against the resolved local `llama-server --help` and tightened three comment-clarity items (revisit condition scope, reasoning-format wording, host-memory vs KV cache distinction).

## References
N/A
