### PR TITLE
Bump nixpkgs to pull in VS Code 1.124.2 (CVE-2026-47284)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -98,11 +98,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781533608,
-        "narHash": "sha256-Mgsu/x5cs8EqlhIQ7bMBo14LpkAYtgzDbG/S/eattJA=",
+        "lastModified": 1781667738,
+        "narHash": "sha256-OxrwHpsWf+QGbos1LMDGAcv7sjBGshcw/43th6waeYI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8aec76cc1e045f37b55d82ca3cee4910ae04d3db",
+        "rev": "7664e05e2413d5e2b8c54a884eb8ea0f8a504fc2",
         "type": "github"
       },
       "original": {
@@ -133,11 +133,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781454065,
-        "narHash": "sha256-d2xfDjnfRuf/xYGdu9VVRHiav/2w5hDL/5cw2TuVAXw=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9eac87a12312b8f60dd52e1c6e1a265f6fc7f5fc",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {
@@ -251,11 +251,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1781518176,
-        "narHash": "sha256-Jle852Ag7NPG5sE+FbRk3wqkWIHUPDIgZPcCo9ssSIQ=",
+        "lastModified": 1781621781,
+        "narHash": "sha256-KIF+P5bBhoYo6MhLUz2HpLD7HCXra3AYUoftdWwEHkw=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "652a739826b9f54a0161fd2cf385c3259db24f32",
+        "rev": "dd7eb6d72ae179aa940e50cd6276ec5646f306f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION


## Why
VS Code 1.123.0 shipped by the previous nixpkgs pin contains CVE-2026-47284 (GHSA-qcxw-jfff-cxpc, High): the GitHub credential provider's hostname regex is unanchored, so a `.gitmodules` entry pointing at `github.com.attacker.example` receives the user's Basic-auth token during recursive clone / submodule update. This repository uses submodules in normal workflow (`.submodules/`), putting it directly in the documented attack profile. The fix landed in VS Code 1.123.1 (2026-06-10).

## What
- Run `nix flake update` rather than pinning vscode out-of-band, since the flake already tracks `nixpkgs-unstable` and unstable HEAD already ships 1.124.2 (>= 1.123.1). A targeted overlay would add maintenance cost for a transient version skew.
- Accept the incidental serena bump (`652a739` → `dd7eb6d`, 5 commits) and home-manager bump that ride along with the same `flake update`. The serena diff is unrelated to the open subprocess-env / unencrypted-memory findings tracked separately in the routine security audit, so this PR does not claim to address them — they remain upstream-blocked.
- Out of scope: VS Code Desktop is not affected by the widely-publicized github.dev 1-click webview/postMessage OAuth zero-day from the same week (Microsoft confirmed Desktop unaffected; github.dev mitigated server-side), so no Desktop-side action is needed for that issue.

## References
N/A
