### PR TITLE
Drop Discord and Zoom from home packages

### DIFF
--- a/home/private/default.nix
+++ b/home/private/default.nix
@@ -20,11 +20,9 @@
   };
 
   home.packages = with pkgs; [
-    discord
     iina
     ripgrep
     slack
-    zoom-us
   ];
 
   imports = [


### PR DESCRIPTION


## Why
Nix-managed Discord on darwin fails to launch: its Python pre-launch wrapper crashes with `PermissionError: Operation not permitted` when writing `~/Library/Application Support/discord/settings.json`. The file carries `com.apple.provenance` from the official signed Discord.app, and macOS App Management blocks the differently-signed `/nix/store/.../python3` from modifying it. Zoom is the same class of app — both depend on aggressive auto-update and on Privacy & Security grants (camera/mic/screen-recording) tied to a stable code signature, which Nix store-path churn invalidates.

## What
- **Hand both apps off to the official installers** rather than work around App Management. Per-launch `xattr -d com.apple.provenance` would lose to the next official-app write (cat-and-mouse), and even when Discord launches the wrapper script's `SKIP_HOST_UPDATE` flag only postpones the real failure mode: Discord eventually API-locks out clients running below the current host version.
- **Pin-an-older-version-and-disable-the-wrapper was rejected** for the same reason — the provenance collision is structural, not a one-off bug, and Zoom's permission story makes it even less viable there (forced updates often gate meeting access, and lost camera/mic grants surface as silent failures mid-call).
- **Slack intentionally kept.** Same class of app, but no acute symptoms today; will revisit if it starts hitting the same App Management collisions or forced-update lockouts.

## References
N/A
