### PR TITLE
Push commits before replying in github-pull-request-respond skill

### DIFF
--- a/config/agents/skills/github-pull-request-respond/SKILL.md
+++ b/config/agents/skills/github-pull-request-respond/SKILL.md
@@ -41,7 +41,7 @@ Respond to review comments on the current GitHub Pull Request by fixing code and
    On push failure:
    - STOP immediately. Do not call any reply API with a hash that is not on the remote.
    - Do NOT run `git push --force`, `git push --force-with-lease`, `git reset --hard`, or any other history-rewriting command on your own — they can silently overwrite a teammate's work.
-   - Surface the raw error to the user, then offer read-only diagnostics (e.g. `git fetch && git log --oneline HEAD..@{u}` and the reverse, to inspect divergence). The user investigates the divergence and decides how to recover; do not enumerate recovery commands on their behalf.
+   - Surface the raw error to the user, then offer read-only diagnostics. Start with `git fetch && git status -sb` to confirm whether an upstream is configured (a missing upstream is a common cause when pushing a new branch for the first time, and `@{u}` errors when no upstream is set). When an upstream exists, follow up with `git log --oneline HEAD..@{u}` and the reverse to inspect divergence. The user investigates and decides how to recover; do not enumerate recovery commands on their behalf.
 
 5. **Reply via API** (do not use `gh pr review`):
    ```sh

--- a/config/agents/skills/github-pull-request-respond/SKILL.md
+++ b/config/agents/skills/github-pull-request-respond/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-pull-request-respond
-description: Respond to unreplied review comments on the current GitHub Pull Request. For each comment, either commit a fix and reply with the commit hash, or reply with concrete rationale for keeping the code as-is. Does not approve, request changes, or push.
+description: Respond to unreplied review comments on the current GitHub Pull Request. For each comment, either commit a fix, push, and reply with the commit hash, or reply with concrete rationale for keeping the code as-is. Does not approve or request changes.
 ---
 
 # Pull Request Respond
@@ -23,34 +23,44 @@ Respond to review comments on the current GitHub Pull Request by fixing code and
      ( [.[] | select(.in_reply_to_id == null and .user.login != \"${MY_LOGIN}\") | .id] ) as \$roots |
      ( [.[] | select(.user.login == \"${MY_LOGIN}\" and .in_reply_to_id != null) | .in_reply_to_id] ) as \$replied |
      (\$roots - \$replied) as \$unreplied_ids |
-     [.[] | select(.id | IN(\$unreplied_ids[])) | {id, path, line, body}]
+     [.[] | select(.id | IN(\$unreplied_ids[])) | {id, user: .user.login, path, line, body}]
    "
    ```
-   This returns an array of unreplied comment objects. If the array is empty (`[]`), all comments have been addressed.
+   This returns an array of unreplied comment objects. If the array is empty (`[]`), all comments have been addressed. The `user` field is required by Step 5's `@<login>` rule and `[bot]` check — keep it in the projection.
 
 3. **For each unreplied comment**:
    - Read the referenced code and understand the reviewer's concern
-   - Code fix needed: fix, commit, then reply with full 40-char commit hash
-   - No fix needed: reply with concrete rationale for why the current code is correct
+   - Code fix needed: fix and commit (full 40-char hash captured via `git log -1 --format='%H'`)
+   - No fix needed: prepare concrete rationale for why the current code is correct
    - One commit per fix (multiple minor fixes may share one commit)
 
-4. **Reply via API** (do not use `gh pr review`):
+4. **Push all commits for this batch** before replying so the hashes are reachable from GitHub:
+   ```sh
+   git push
+   ```
+   On push failure:
+   - STOP immediately. Do not call any reply API with a hash that is not on the remote.
+   - Do NOT run `git push --force`, `git push --force-with-lease`, `git reset --hard`, or any other history-rewriting command on your own — they can silently overwrite a teammate's work.
+   - Surface the raw error to the user, then offer read-only diagnostics (e.g. `git fetch && git log --oneline HEAD..@{u}` and the reverse, to inspect divergence). The user investigates the divergence and decides how to recover; do not enumerate recovery commands on their behalf.
+
+5. **Reply via API** (do not use `gh pr review`):
    ```sh
    gh api "repos/${OWNER_REPO}/pulls/${PR_NUM}/comments/<ROOT_ID>/replies" \
      -f body="<reply text>"
    ```
+   Address the reviewer with `@<login>` at the top of the reply so they get notified. Skip the mention for bots whose login ends with `[bot]` (e.g. `copilot-pull-request-reviewer[bot]`, `coderabbitai[bot]`) — they will not be notified by mentions.
 
-5. **Summarize** all changes and replies
+6. **Summarize** all changes and replies
 
 ## Rules
 
 - Reply only; do not approve, request changes, or submit a review
-- Do not push; the user will push manually
+- Push committed fixes before replying so the referenced commit hash is reachable from GitHub
 - Reply in the same language as the reviewer's comment
 - Always use `--paginate` when fetching comments (PRs may have 30+ comments)
 - Use `git log -1 --format='%H'` to get the full commit hash for GitHub autolink
 - Separate the commit hash and any `#NNN` issue/PR reference from surrounding text with an ASCII space or a newline on both sides. In Japanese or other non-space-delimited languages, GitHub's autolink detection will not fire if the hash is adjacent to a non-ASCII character (e.g. `修正しました。deadbeef...` stays as plain text). Safest format: put the hash on its own line.
-- Do not reply until all fixes for the current batch are committed
+- Do not reply until all fixes for the current batch are committed AND pushed
 
 ## Caveats
 

--- a/config/agents/skills/github-pull-request-respond/SKILL.md
+++ b/config/agents/skills/github-pull-request-respond/SKILL.md
@@ -20,13 +20,13 @@ Respond to review comments on the current GitHub Pull Request by fixing code and
    PR_NUM=$(gh pr view --json number -q .number)
    MY_LOGIN=$(gh api user -q .login)
    gh api "repos/${OWNER_REPO}/pulls/${PR_NUM}/comments" --paginate --jq "
-     ( [.[] | select(.in_reply_to_id == null and .user.login != \"${MY_LOGIN}\") | .id] ) as \$roots |
-     ( [.[] | select(.user.login == \"${MY_LOGIN}\" and .in_reply_to_id != null) | .in_reply_to_id] ) as \$replied |
+     ( [.[] | select(.in_reply_to_id == null and .user?.login != \"${MY_LOGIN}\") | .id] ) as \$roots |
+     ( [.[] | select(.user?.login == \"${MY_LOGIN}\" and .in_reply_to_id != null) | .in_reply_to_id] ) as \$replied |
      (\$roots - \$replied) as \$unreplied_ids |
-     [.[] | select(.id | IN(\$unreplied_ids[])) | {id, user: .user.login, path, line, body}]
+     [.[] | select(.id | IN(\$unreplied_ids[])) | {id, user: (.user?.login // \"ghost\"), path, line, body}]
    "
    ```
-   This returns an array of unreplied comment objects. If the array is empty (`[]`), all comments have been addressed. The `user` field is required by Step 5's `@<login>` rule and `[bot]` check — keep it in the projection.
+   This returns an array of unreplied comment objects. If the array is empty (`[]`), all comments have been addressed. The `user` field is required by Step 5's `@<login>` rule and `[bot]`/`ghost` check — keep it in the projection. Optional chaining (`.user?.login`) and the `"ghost"` fallback are required: GitHub returns `null` for `.user` when an account has been deleted, and a bare `.user.login` would crash jq.
 
 3. **For each unreplied comment**:
    - Read the referenced code and understand the reviewer's concern
@@ -48,7 +48,7 @@ Respond to review comments on the current GitHub Pull Request by fixing code and
    gh api "repos/${OWNER_REPO}/pulls/${PR_NUM}/comments/<ROOT_ID>/replies" \
      -f body="<reply text>"
    ```
-   Address the reviewer with `@<login>` at the top of the reply so they get notified. Skip the mention for bots whose login ends with `[bot]` (e.g. `copilot-pull-request-reviewer[bot]`, `coderabbitai[bot]`) — they will not be notified by mentions.
+   Address the reviewer with `@<login>` at the top of the reply so they get notified. Skip the mention when the login (a) ends with `[bot]` (e.g. `copilot-pull-request-reviewer[bot]`, `coderabbitai[bot]`) — bots are not notified by mentions; or (b) is exactly `ghost` — this is the GitHub placeholder for a deleted account, and mentioning it would notify an unrelated real user named `ghost`.
 
 6. **Summarize** all changes and replies
 

--- a/config/agents/skills/github-pull-request-respond/SKILL.md
+++ b/config/agents/skills/github-pull-request-respond/SKILL.md
@@ -30,9 +30,9 @@ Respond to review comments on the current GitHub Pull Request by fixing code and
 
 3. **For each unreplied comment**:
    - Read the referenced code and understand the reviewer's concern
-   - Code fix needed: fix and commit (full 40-char hash captured via `git log -1 --format='%H'`)
+   - Code fix needed: fix and commit. Capture the full 40-char hash **immediately after each commit**, labeled by the comment ID it addresses (e.g. `HASH_<commentID>=$(git log -1 --format='%H')`). Do NOT defer hash capture to after the loop — `git log -1` always points at the most recent commit, so deferring loses every earlier hash in the batch.
    - No fix needed: prepare concrete rationale for why the current code is correct
-   - One commit per fix (multiple minor fixes may share one commit)
+   - One commit per fix (multiple minor fixes may share one commit; if multiple comments share a commit, label the same hash under each comment's ID)
 
 4. **Push all commits for this batch** before replying so the hashes are reachable from GitHub:
    ```sh


### PR DESCRIPTION


## Why
The skill previously committed fixes and posted replies but explicitly deferred `git push` to the user. Every reply therefore went out referencing a commit hash that GitHub could not resolve until the user manually pushed — breaking the autolink and leaving reviewers without a clickable trail to the fix. Closing the loop in the skill itself is the only way the referenced hash is guaranteed reachable when the reply hits the API.

## What
- Move `git push` into the skill between commit and reply so reply hashes are always live when posted. The push runs unconditionally; richer flows (per-comment confidence evaluation, user approval gates) were considered as inspirations from existing work but rejected as larger behavior changes than the bug warrants.
- Lift reviewer `@<login>` mentions into the reply step, with a `[bot]`-suffix exception that skips mentions for accounts that would not be notified anyway. Surfacing the `user` field through the comment-fetch jq projection feeds the data the new mention rule needs (caught during empirical evaluation — the old projection dropped it).
- Harden the push failure path: stop immediately, ban executor-driven destructive recoveries (`--force`, `--force-with-lease`, `reset --hard`), surface the raw error, and offer only read-only diagnostics. An earlier draft named `--force-with-lease` as a recommended remediation; empirical evaluation flagged this as contradicting the no-destructive-op stance, so the final guard hands recovery to the user without enumerating commands.

## References
N/A
