### PR TITLE
Build terminal-notifier from source for native arm64 binary

### DIFF
--- a/modules/shared/agents-claude-code.nix
+++ b/modules/shared/agents-claude-code.nix
@@ -23,7 +23,8 @@ in
 
   home.packages = [
     # Used by config/agents/scripts/notify.sh (symlinked into .claude/scripts).
-    pkgs.terminal-notifier
+    # customPackages override: nixpkgs ships Intel-only zip, this builds arm64 from source.
+    pkgs.customPackages.terminal-notifier
     # MCP server launched via ~/.claude.json (not Nix-managed); only Claude
     # Code wires serena as an MCP server, so it is owned here.
     flakeInputs.serena

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -14,4 +14,5 @@ rec {
   opencode-sandboxed = pkgs.callPackage ./opencode-sandboxed {
     inherit opencode-bin;
   };
+  terminal-notifier = pkgs.callPackage ./terminal-notifier { };
 }

--- a/packages/terminal-notifier/default.nix
+++ b/packages/terminal-notifier/default.nix
@@ -1,0 +1,69 @@
+# terminal-notifier built from source for arm64-native macOS binaries.
+#
+# Upstream nixpkgs ships a fetchzip of the alloy/terminal-notifier 2.0.0
+# release asset, which is an Intel-only Mach-O. Running it on Apple Silicon
+# triggers the macOS 26 "translated via Rosetta" warning. This derivation
+# mirrors the approach in NixOS/nixpkgs#515280 — build the julienXX fork
+# from source with xcbuildHook so the produced binary matches the host arch.
+#
+# Remove this override and switch back to pkgs.terminal-notifier once one
+# of the upstream PRs (#515280 / #529756) lands.
+{
+  apple-sdk,
+  fetchFromGitHub,
+  ibtool,
+  lib,
+  makeBinaryWrapper,
+  stdenv,
+  xcbuildHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "terminal-notifier";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "julienXX";
+    repo = "terminal-notifier";
+    tag = finalAttrs.version;
+    hash = "sha256-Hd9cI3R2nQK2deBb5CBYz4DTHAEcO4vzqtA5qZwa1Ao=";
+  };
+
+  nativeBuildInputs = [
+    ibtool
+    makeBinaryWrapper
+    xcbuildHook
+  ];
+
+  buildInputs = [
+    apple-sdk
+  ];
+
+  xcbuildFlags = [
+    "-target"
+    "terminal-notifier"
+    "-configuration"
+    "Release"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{Applications,bin}
+    cp -r Products/Release/terminal-notifier.app $out/Applications/
+    makeWrapper \
+      $out/Applications/terminal-notifier.app/Contents/MacOS/terminal-notifier \
+      $out/bin/terminal-notifier \
+      --chdir $out/Applications/terminal-notifier.app
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Send macOS User Notifications from the command-line";
+    homepage = "https://github.com/julienXX/terminal-notifier";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.darwin;
+    mainProgram = "terminal-notifier";
+  };
+})

--- a/packages/terminal-notifier/default.nix
+++ b/packages/terminal-notifier/default.nix
@@ -9,12 +9,12 @@
 # Remove this override and switch back to pkgs.terminal-notifier once one
 # of the upstream PRs (#515280 / #529756) lands.
 {
-  apple-sdk,
-  fetchFromGitHub,
-  ibtool,
   lib,
-  makeBinaryWrapper,
   stdenv,
+  fetchFromGitHub,
+  apple-sdk,
+  ibtool,
+  makeBinaryWrapper,
   xcbuildHook,
 }:
 


### PR DESCRIPTION


## Why
`pkgs.terminal-notifier` in nixpkgs is a `fetchzip` of the alloy/terminal-notifier 2.0.0 release asset, which is an Intel-only Mach-O. On Apple Silicon under macOS 26 every invocation surfaces a "translated via Rosetta" system notification and pays Rosetta startup overhead, which the agent notify hook triggers on every Claude Code turn. Two upstream nixpkgs PRs (#515280 and #529756) propose the same source-build fix but have sat without a single review for ~50 and ~10 days respectively, so waiting is unbounded.

## What
- Considered three paths: wait for one of the upstream PRs to land, `overrideAttrs` the existing nixpkgs derivation in `lib/overlays.nix`, or vendor a local package that mirrors the upstream PR.
- Rejected "wait": no maintainer activity, while warnings continue on every notification.
- Rejected `overrideAttrs`: replacing `src`, `nativeBuildInputs`, and `installPhase` wholesale is not really an override — it hides the derivation inside an overlay and reads worse than a plain file.
- Chose to vendor under `packages/terminal-notifier/` following the repo's existing `customPackages` convention. The derivation is a verbatim port of nixpkgs PR #515280 (which itself uses the in-tree `xcbuildHook` + `ibtool` + `apple-sdk`, so the Nix sandbox builds it without Xcode), and the single call site in `agents-claude-code.nix` is switched to `pkgs.customPackages.terminal-notifier`.
- Exit plan is intentionally trivial: once either upstream PR lands and reaches nixpkgs-unstable, delete `packages/terminal-notifier/`, remove the one line from `packages/default.nix`, and revert the call site to `pkgs.terminal-notifier` — three-file diff, no hidden state.

## References
- NixOS/nixpkgs#515280
- NixOS/nixpkgs#529756
