### PR TITLE
Detect bots by user.type in github-pull-request-respond skill

### DIFF
--- a/config/agents/skills/github-pull-request-respond/SKILL.md
+++ b/config/agents/skills/github-pull-request-respond/SKILL.md
@@ -23,10 +23,10 @@ Respond to review comments on the current GitHub Pull Request by fixing code and
      ( [.[] | select(.in_reply_to_id == null and .user?.login != \"${MY_LOGIN}\") | .id] ) as \$roots |
      ( [.[] | select(.user?.login == \"${MY_LOGIN}\" and .in_reply_to_id != null) | .in_reply_to_id] ) as \$replied |
      (\$roots - \$replied) as \$unreplied_ids |
-     [.[] | select(.id | IN(\$unreplied_ids[])) | {id, user: (.user?.login // \"ghost\"), path, line, body}]
+     [.[] | select(.id | IN(\$unreplied_ids[])) | {id, user: (.user?.login // \"ghost\"), user_type: (.user?.type // \"\"), path, line, body}]
    "
    ```
-   This returns an array of unreplied comment objects. If the array is empty (`[]`), all comments have been addressed. The `user` field is required by Step 5's `@<login>` rule and `[bot]`/`ghost` check — keep it in the projection. Optional chaining (`.user?.login`) and the `"ghost"` fallback are required: GitHub returns `null` for `.user` when an account has been deleted, and a bare `.user.login` would crash jq.
+   This returns an array of unreplied comment objects. If the array is empty (`[]`), all comments have been addressed. The `user` and `user_type` fields are required by Step 5's `@<login>` rule and bot/ghost check — keep both in the projection. Optional chaining (`.user?.login`, `.user?.type`) and the `"ghost"` / `""` fallbacks are required: GitHub returns `null` for `.user` when an account has been deleted, and a bare `.user.login` would crash jq.
 
 3. **For each unreplied comment**:
    - Read the referenced code and understand the reviewer's concern
@@ -48,7 +48,7 @@ Respond to review comments on the current GitHub Pull Request by fixing code and
    gh api "repos/${OWNER_REPO}/pulls/${PR_NUM}/comments/<ROOT_ID>/replies" \
      -f body="<reply text>"
    ```
-   Address the reviewer with `@<login>` at the top of the reply so they get notified. Skip the mention when the login (a) ends with `[bot]` (e.g. `copilot-pull-request-reviewer[bot]`, `coderabbitai[bot]`) — bots are not notified by mentions; or (b) is exactly `ghost` — this is the GitHub placeholder for a deleted account, and mentioning it would notify an unrelated real user named `ghost`.
+   Address the reviewer with `@<login>` at the top of the reply so they get notified. Skip the mention when (a) `user_type == "Bot"` — bots are not notified by mentions, and the `[bot]` suffix is unreliable as a marker because GitHub returns the bare login `Copilot` (no suffix) for the Copilot reviewer while still setting `type == "Bot"`; or (b) the login is exactly `ghost` — this is the GitHub placeholder for a deleted account, and mentioning it would notify an unrelated real user named `ghost`. Reply itself is still required for bots (including Copilot) — only the leading mention is omitted.
 
 6. **Summarize** all changes and replies
 

--- a/config/agents/skills/github-pull-request-respond/SKILL.md
+++ b/config/agents/skills/github-pull-request-respond/SKILL.md
@@ -26,7 +26,7 @@ Respond to review comments on the current GitHub Pull Request by fixing code and
      [.[] | select(.id | IN(\$unreplied_ids[])) | {id, user: (.user?.login // \"ghost\"), user_type: (.user?.type // \"\"), path, line, body}]
    "
    ```
-   This returns an array of unreplied comment objects. If the array is empty (`[]`), all comments have been addressed. The `user` and `user_type` fields are required by Step 5's `@<login>` rule and bot/ghost check — keep both in the projection. Optional chaining (`.user?.login`, `.user?.type`) and the `"ghost"` / `""` fallbacks are required: GitHub returns `null` for `.user` when an account has been deleted, and a bare `.user.login` would crash jq.
+   This returns an array of unreplied comment objects. If the array is empty (`[]`), all comments have been addressed. The `user` and `user_type` fields are required by Step 5's `@<login>` rule and bot/ghost check — keep both in the projection. The trailing `?` in `.user?.login` / `.user?.type` is jq's error-suppression operator (not JavaScript-style optional chaining); combined with the `"ghost"` / `""` defaults via `//`, it keeps the pipeline safe when GitHub returns `null` for `.user` (deleted account) — a bare `.user.login` against `null` would crash jq with `Cannot index null with "login"`. Default fallbacks: missing login → `"ghost"`, missing user type → `""`.
 
 3. **For each unreplied comment**:
    - Read the referenced code and understand the reviewer's concern
@@ -48,7 +48,7 @@ Respond to review comments on the current GitHub Pull Request by fixing code and
    gh api "repos/${OWNER_REPO}/pulls/${PR_NUM}/comments/<ROOT_ID>/replies" \
      -f body="<reply text>"
    ```
-   Address the reviewer with `@<login>` at the top of the reply so they get notified. Skip the mention when (a) `user_type == "Bot"` — bots are not notified by mentions, and the `[bot]` suffix is unreliable as a marker because GitHub returns the bare login `Copilot` (no suffix) for the Copilot reviewer while still setting `type == "Bot"`; or (b) the login is exactly `ghost` — this is the GitHub placeholder for a deleted account, and mentioning it would notify an unrelated real user named `ghost`. Reply itself is still required for bots (including Copilot) — only the leading mention is omitted.
+   Address the reviewer with `@<login>` at the top of the reply so they get notified. Skip the mention when (a) `user_type == "Bot"` (mirrors the API's `.user.type` field, surfaced as `user_type` in Step 2's projection) — bots are not notified by mentions, and the `[bot]` suffix on the login is unreliable as a marker because GitHub returns the bare login `Copilot` (no suffix) for the Copilot reviewer while still setting `.user.type == "Bot"`; or (b) the login is exactly `ghost` — this is the GitHub placeholder for a deleted account, and mentioning it would notify an unrelated real user named `ghost`. Reply itself is still required for bots (including Copilot) — only the leading mention is omitted.
 
 6. **Summarize** all changes and replies
 


### PR DESCRIPTION


## Why
The skill's mention-skip rule for bots used `endswith("[bot]")` on the comment author's login, but the GitHub PR review comments API returns the Copilot reviewer with the bare login `Copilot` (no `[bot]` suffix). The existing rule therefore failed open for Copilot, and replies to Copilot review comments would have prepended a literal `@Copilot` mention — pinging whichever real user GitHub maps that handle to.

## What
Switched the bot marker from the login-suffix heuristic to `user.type == "Bot"`, which the same API already returns alongside the login (verified across all bot commenters observed in this repo: `Copilot`, `coderabbitai[bot]`, `gemini-code-assist[bot]`). The Step 2 jq projection now also surfaces `user_type` so Step 5 can read it without an extra API round-trip. Considered keeping the suffix check and special-casing `Copilot`, but a one-off allowlist would silently break again the next time a bot is added with a non-suffixed login — gating on the authoritative `type` field is the durable fix. Reply behavior is unchanged: bots still receive a reply, only the leading `@mention` is omitted.

## References
N/A
