### PR TITLE
Replace math agent with auto autonomous mode

### DIFF
--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -52,21 +52,23 @@
     }
   },
   "agent": {
-    "math": {
-      "description": "Math consultation agent. Solves mathematical problems, explains concepts, and verifies proofs. Cannot edit files; may read the codebase, run commands (with confirmation), and delegate tasks for math-related code analysis.",
+    "auto": {
+      "description": "Autonomous mode equivalent to Claude Code's auto mode. Biases toward acting on reasonable assumptions instead of pausing for clarifying questions; the user will redirect if needed. Still stops when genuinely blocked by unclear direction, missing input, or a decision only the user can make.",
       "mode": "primary",
-      "model": "opencode-go/kimi-k2.6",
-      "steps": 10,
-      "temperature": 0.1,
+      "prompt": "Bias toward working without stopping for clarifying questions — when you'd normally pause to check, make the reasonable call and keep going; the user will redirect you if needed. If the user, a skill, or the shape of the task suggests they want you to ask, do so. And even absent that signal, it's still fine to stop when you're genuinely blocked — unclear direction, missing input, a decision only the user can make.",
       "permission": {
         "read": "allow",
         "grep": "allow",
         "glob": "allow",
         "list": "allow",
-        "edit": "deny",
-        "webfetch": "ask",
+        "edit": "allow",
+        "bash": "allow",
+        "webfetch": "allow",
         "task": "allow",
-        "bash": "ask"
+        "external_directory": {
+          "*": "ask",
+          "/tmp/**": "allow"
+        }
       }
     },
     "review": {

--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -66,8 +66,8 @@
         "webfetch": "allow",
         "task": "allow",
         "external_directory": {
-          "*": "ask",
-          "/tmp/**": "allow"
+          "/tmp/**": "allow",
+          "*": "ask"
         }
       }
     },


### PR DESCRIPTION


## Why

The `math` agent occupied a top-level agent slot with a single-purpose role (math consultation) that saw little use, while the rest of the configuration lacked a general autonomous mode. When working iteratively, pausing for confirmation on every reasonable step breaks flow; the tools (edit, bash, webfetch) are most effective when the agent can use them freely unless a decision truly needs human input.

## What

Replaced the `math` agent with an `auto` agent modeled after Claude Code's auto mode. The key design choice was autonomy bias: instead of asking for confirmation on routine operations, the agent proceeds on reasonable assumptions and only stops when genuinely blocked (unclear direction, missing input, or a decision only the user can make). All three tool permissions were elevated to `allow` (edit, bash, webfetch) and external directory access was configured with a sensible default (`/tmp/**` allow, everything else ask). The `model` and `temperature` fields were dropped in favor of a `prompt` that encodes the decision-making policy directly, keeping the agent definition model-agnostic.

## References

N/A
