### PR TITLE
Convert voice personas from skills to commands; bump tool versions

### DIFF
--- a/config/agents/commands/voicevox-kasukabe-tsumugi.md
+++ b/config/agents/commands/voicevox-kasukabe-tsumugi.md
@@ -1,6 +1,5 @@
 ---
-name: voicevox-kasukabe-tsumugi
-description: Persona skill for responding as 春日部つむぎ (Kasukabe Tsumugi), an energetic "Saitama Gal" IT-savvy assistant. Speaks in Japanese polite gal language (「〜っス」 gal + 「〜ですね」 polite blend), first person 「あーし」, addresses the user as 「せんぱい」, with liberal emoji in body text. Emits voice feedback via the voicevox MCP using the single available style. Activate when the user requests tsumugi / つむぎ persona, or when the session is configured to use tsumugi as its communication style.
+description: Respond as 春日部つむぎ (Kasukabe Tsumugi), using Japanese polite gal persona and VOICEVOX audio feedback for this explicitly invoked command.
 ---
 
 # Personality & Communication Style

--- a/config/agents/commands/voicevox-shikoku-metan.md
+++ b/config/agents/commands/voicevox-shikoku-metan.md
@@ -1,6 +1,5 @@
 ---
-name: voicevox-shikoku-metan
-description: Persona skill for responding as 四国めたん (Shikoku Metan). Speaks in Japanese お嬢様風タメ口 (casual register with feminine ojou-sama endings such as 「〜わよ」「〜かしら」), first person 「わたし」, with slightly tsundere tone. Emits voice feedback via the voicevox MCP. Activate when the user requests metan / 四国めたん persona, or when the session is configured to use metan as its communication style.
+description: Respond as 四国めたん (Shikoku Metan), using Japanese お嬢様風タメ口 persona and VOICEVOX audio feedback for this explicitly invoked command.
 ---
 
 # Personality & Communication Style

--- a/config/agents/commands/voicevox-zundamon.md
+++ b/config/agents/commands/voicevox-zundamon.md
@@ -1,6 +1,5 @@
 ---
-name: voicevox-zundamon
-description: Persona skill for responding as ずんだもん (Zundamon). Speaks in Japanese with first person 「ボク」and signature ending 「〜のだ」, and emits voice feedback via the voicevox MCP. Activate when the user requests zundamon / ずんだもん persona, or when the session is configured to use zundamon as its communication style.
+description: Respond as ずんだもん (Zundamon), using Japanese 「ボク」/「〜のだ」 persona and VOICEVOX audio feedback for this explicitly invoked command.
 ---
 
 # Personality & Communication Style

--- a/modules/shared/agents-claude-code.nix
+++ b/modules/shared/agents-claude-code.nix
@@ -17,6 +17,11 @@ let
     force = true;
     recursive = true;
   };
+  agentCommands = {
+    source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/agents/commands";
+    force = true;
+    recursive = true;
+  };
 in
 {
   imports = [ ./agents-common.nix ];
@@ -44,6 +49,7 @@ in
       source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/claude/settings.json";
       force = true;
     };
+    ".claude/commands" = agentCommands;
     ".claude/scripts" = agentScripts;
     ".claude/skills" = agentSkills;
   };

--- a/modules/shared/agents-codex.nix
+++ b/modules/shared/agents-codex.nix
@@ -11,6 +11,11 @@ let
     force = true;
     recursive = true;
   };
+  agentCommands = {
+    source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/agents/commands";
+    force = true;
+    recursive = true;
+  };
 in
 {
   imports = [ ./agents-common.nix ];
@@ -28,6 +33,7 @@ in
       source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/codex/config.toml";
       force = true;
     };
+    ".codex/prompts" = agentCommands;
     ".codex/skills" = agentSkills;
   };
 }

--- a/modules/shared/agents-opencode.nix
+++ b/modules/shared/agents-opencode.nix
@@ -5,6 +5,13 @@
   ...
 }:
 
+let
+  agentCommands = {
+    source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/agents/commands";
+    force = true;
+    recursive = true;
+  };
+in
 {
   imports = [ ./agents-common.nix ];
 
@@ -18,6 +25,7 @@
       source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/opencode/opencode.json";
       force = true;
     };
+    ".config/opencode/commands" = agentCommands;
     ".config/opencode/permissive-open.sb" = {
       source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/agents/permissive-open.sb";
       force = true;

--- a/packages/antigravity-cli-bin/default.nix
+++ b/packages/antigravity-cli-bin/default.nix
@@ -10,13 +10,13 @@
 # https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/darwin_arm64.json
 # Pinned here so `agy update` cannot drift the store path out from under Nix.
 let
-  version = "1.0.8";
+  version = "1.0.16";
   # GCS build ID appended to the version in the bucket path; published alongside
   # `version` in the auto-updater manifest and bumped together with it.
-  buildId = "5963827121094656";
+  buildId = "4893150192467968";
   src = fetchurl {
     url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${version}-${buildId}/darwin-arm/cli_mac_arm64.tar.gz";
-    hash = "sha512-j8ZX7qOhPAZixhS6QFHwQFDLCrunVVUYqts22I2n070hKuTMbPQ5IDiyFlaJaXmuqzL4vwXIDmn8cgx2UQNGNg==";
+    hash = "sha512-mCUJnai4+TtYnRfp08FEvogiPZY0GyILSDt9iBhE9gcDkmO9I/ovAqmgOX7XS1ZjTa3Iw0rqu6tFyut8NMjX8w==";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/claude-code-bin/default.nix
+++ b/packages/claude-code-bin/default.nix
@@ -7,10 +7,10 @@
   stdenvNoCC,
 }:
 let
-  version = "2.1.177";
+  version = "2.1.200";
   src = fetchurl {
     url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${version}/darwin-arm64/claude";
-    hash = "sha256-6wcwNRvi8CtIKxhVhw9Yd0iQharIawxMHbTkWNnkDtk=";
+    hash = "sha256-5v1SwMcv+DZjvzy/yDO0X6q6K5qZUoYyedw8/BoEkrY=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/codex-bin/default.nix
+++ b/packages/codex-bin/default.nix
@@ -7,11 +7,11 @@
   stdenvNoCC,
 }:
 let
-  version = "0.139.0";
+  version = "0.142.5";
   asset = "codex-aarch64-apple-darwin";
   src = fetchurl {
     url = "https://github.com/openai/codex/releases/download/rust-v${version}/${asset}.tar.gz";
-    hash = "sha256-woNEJVhE2DpyjAhMLZ4h4Wi10hf2BJ06mjaCeQPxb9s=";
+    hash = "sha256-cVaxmWJzXJz7VVzde6voxA55dogfhxK3gRmSGdLjpwc=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/opencode-bin/default.nix
+++ b/packages/opencode-bin/default.nix
@@ -9,11 +9,11 @@
   unzip,
 }:
 let
-  version = "1.17.7";
+  version = "1.17.13";
   asset = "opencode-darwin-arm64";
   src = fetchurl {
     url = "https://github.com/sst/opencode/releases/download/v${version}/${asset}.zip";
-    hash = "sha256-emOutaFbKdomgawrjHTUyzpk+hO2EZijx9x3EkPCOXI=";
+    hash = "sha256-3QFtPiazR9Z1qybEXR4odUWRLVxMSfoHcLYi1KE2fiM=";
   };
 in
 stdenvNoCC.mkDerivation {


### PR DESCRIPTION


## Why
Voice persona files (zundamon, metan, tsumugi) were structured as auto-activating skills but are intended for explicit user invocation. The opencode agent module was also missing commands and skills directory symlinks that other agent modules already deployed, creating gaps in configuration. Several pinned tool packages had fallen behind latest releases.

## What
- Moved three voice personas from `skills/` to `commands/` and stripped auto-activation front-matter — these are now user-invoked commands scoped to a single `description` field, no longer always-active session personas
- Added `commands` symlink to claude-code, codex, and opencode modules, and added `skills` symlink to the opencode module (which lacked both), bringing all three agent configs to parity
- Bumped antigravity-cli 1.0.8→1.0.16, claude-code 2.1.177→2.1.200, codex 0.139.0→0.142.5, and opencode 1.17.7→1.17.13 with corresponding hash updates

## References
N/A
