### PR TITLE
Update OpenCode config: skill paths, slack MCP, model switch

### DIFF
--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -2,6 +2,11 @@
   "$schema": "https://opencode.ai/config.json",
   "autoupdate": false,
   "autoshare": false,
+  "skills": {
+    "paths": [
+      "skills"
+    ]
+  },
   "permission": {
     "bash": "ask",
     "edit": "ask",
@@ -29,6 +34,16 @@
         "--no-performance-crux"
       ],
       "timeout": 120000
+    },
+    "slack": {
+      "type": "local",
+      "command": [
+        "slack-mcp-server"
+      ],
+      "env": {
+        "SLACK_USER_TOKEN": "${SLACK_USER_TOKEN}"
+      },
+      "timeout": 120000
     }
   },
   "provider": {
@@ -55,6 +70,7 @@
     "auto": {
       "description": "Autonomous mode equivalent to Claude Code's auto mode. Biases toward acting on reasonable assumptions instead of pausing for clarifying questions; the user will redirect if needed. Still stops when genuinely blocked by unclear direction, missing input, or a decision only the user can make.",
       "mode": "primary",
+      "model": "deepseek-v4-flash",
       "prompt": "Bias toward working without stopping for clarifying questions — when you'd normally pause to check, make the reasonable call and keep going; the user will redirect you if needed. If the user, a skill, or the shape of the task suggests they want you to ask, do so. And even absent that signal, it's still fine to stop when you're genuinely blocked — unclear direction, missing input, a decision only the user can make.",
       "permission": {
         "read": "allow",
@@ -99,6 +115,6 @@
       }
     }
   },
-  "model": "opencode-go/qwen3.7-plus",
+  "model": "deepseek-v4-flash",
   "small_model": "opencode/deepseek-v4-flash-free"
 }

--- a/modules/shared/agents-opencode.nix
+++ b/modules/shared/agents-opencode.nix
@@ -26,6 +26,11 @@ in
       force = true;
     };
     ".config/opencode/commands" = agentCommands;
+    ".config/opencode/skills" = {
+      source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/agents/skills";
+      force = true;
+      recursive = true;
+    };
     ".config/opencode/permissive-open.sb" = {
       source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/agents/permissive-open.sb";
       force = true;


### PR DESCRIPTION


## Why

OpenCode custom skills (at `config/agents/skills/`) were not discoverable because the config lacked a `"skills"` path entry and the Nix home-manager wiring did not symlink the directory into `~/.config/opencode/skills`. Additionally, the MCP server list was incomplete (Slack was wired via the Nix package but not registered in the config), and the default model was still pointing at the deprecated Qwen gateway.

## What

- Add `"skills"` with a `paths` entry pointing to `~/.config/opencode/skills`, which home-manager symlinks to `config/agents/skills/`. This follows the same `mkOutOfStoreSymlink` pattern already used for `commands/` and `permissive-open.sb`.
- Register the Slack MCP server in `opencode.json` so it is available at startup rather than requiring manual addition.
- Switch the default model from `opencode-go/qwen3.7-plus` to `deepseek-v4-flash` (and the `auto` agent model accordingly), matching the current primary model in use.

## References

N/A
