### PR TITLE
Enable app switcher for all displays in dock configuration

### DIFF
--- a/hosts/mac14-10/default.nix
+++ b/hosts/mac14-10/default.nix
@@ -24,6 +24,7 @@
       SoftwareUpdate.AutomaticallyInstallMacOSUpdates = false;
 
       dock = {
+        appswitcher-all-displays = true;
         autohide = true;
         launchanim = false;
         mru-spaces = false;

--- a/hosts/mac14-9/default.nix
+++ b/hosts/mac14-9/default.nix
@@ -23,6 +23,7 @@
       SoftwareUpdate.AutomaticallyInstallMacOSUpdates = false;
 
       dock = {
+        appswitcher-all-displays = true;
         autohide = true;
         launchanim = false;
         mru-spaces = false;


### PR DESCRIPTION


## Why
On a multi-display setup, Cmd+Tab only shows the app switcher on the display where the Dock lives, forcing a glance away from whichever screen you're actually working on.

## What
Set the existing `system.defaults.dock.appswitcher-all-displays` nix-darwin option to `true` on both hosts (`mac14-9`, `mac14-10`) rather than shelling out to `defaults write` — it's a typed option nix-darwin has supported since 2022, so it stays declarative and doesn't need a `killall Dock` activation step.

## References
N/A
