### PR TITLE
feat: add sleepctl — Caps Lock as a physical keep-awake switch

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -13,11 +13,13 @@ web_search = "live"
 personality = "pragmatic"
 project_doc_fallback_filenames = ["CLAUDE.md", "GEMINI.md"]
 
-notify = ["bash", "-lc", "afplay /System/Library/Sounds/Ping.aiff"]
 
 # Features
+notify = ["/Users/gen/.codex/computer-use/Codex Computer Use.app/Contents/SharedSupport/SkyComputerUseClient.app/Contents/MacOS/SkyComputerUseClient", "turn-ended", "--previous-notify", "[\"bash\",\"-lc\",\"afplay \\/System\\/Library\\/Sounds\\/Ping.aiff\"]"]
+
 [features]
 memories = true
+js_repl = false
 
 # Telemetry: disable anonymous usage/health metrics sent to OpenAI (on by default since v0.128.0)
 [analytics]
@@ -51,3 +53,65 @@ command = "chrome-devtools-mcp"
 args = ["--isolated", "--headless", "--channel=stable", "--no-usage-statistics", "--no-performance-crux"]
 startup_timeout_sec = 30
 tool_timeout_sec = 120
+
+[mcp_servers.node_repl]
+args = []
+command = "/Users/gen/Applications/Codex.app/Contents/Resources/cua_node/bin/node_repl"
+startup_timeout_sec = 120
+
+[mcp_servers.node_repl.env]
+NODE_REPL_NATIVE_PIPE_CONNECT_TIMEOUT_MS = "1000"
+NODE_REPL_NODE_MODULE_DIRS = "/Users/gen/Applications/Codex.app/Contents/Resources/cua_node/lib/node_modules"
+NODE_REPL_NODE_PATH = "/Users/gen/Applications/Codex.app/Contents/Resources/cua_node/bin/node"
+NODE_REPL_TRUSTED_CODE_PATHS = "/Users/gen/.codex"
+CODEX_HOME = "/Users/gen/.codex"
+NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S = "feca4d852d7d18eab5e217b18c8c80099fe667c330e836640fd7a48f362de525"
+BROWSER_USE_AVAILABLE_BACKENDS = "chrome,iab"
+NODE_REPL_INSTRUCTIONS_USE_CASE_BROWSER = "Control the in-app browser in conjunction with the Browser Plugin."
+NODE_REPL_INSTRUCTIONS_USE_CASE_CHROME = "Control the Chrome browser in conjunction with the Chrome Plugin. Prefer this method of controlling Chrome over alternatives (such as Computer Use) unless the user explicitly mentions an alternative."
+BROWSER_USE_CODEX_APP_BUILD_FLAVOR = "prod"
+BROWSER_USE_CODEX_APP_VERSION = "26.616.32156"
+CODEX_CLI_PATH = "/Users/gen/Applications/Codex.app/Contents/Resources/codex"
+
+[marketplaces.openai-bundled]
+last_updated = "2026-06-19T13:04:21Z"
+source_type = "local"
+source = "/Users/gen/.codex/.tmp/bundled-marketplaces/openai-bundled"
+
+[marketplaces.openai-primary-runtime]
+last_updated = "2026-06-20T04:11:12Z"
+source_type = "local"
+source = "/Users/gen/.cache/codex-runtimes/codex-primary-runtime/plugins/openai-primary-runtime"
+
+[plugins."browser@openai-bundled"]
+enabled = true
+
+[plugins."documents@openai-primary-runtime"]
+enabled = true
+
+[plugins."pdf@openai-primary-runtime"]
+enabled = true
+
+[plugins."spreadsheets@openai-primary-runtime"]
+enabled = true
+
+[plugins."presentations@openai-primary-runtime"]
+enabled = true
+
+[projects."/Users/gen/ghq/github.com/usabarashi/library"]
+trust_level = "trusted"
+
+[projects."/Users/gen/ghq/github.com/usabarashi/infrastructure"]
+trust_level = "trusted"
+
+[projects."/Users/gen/Documents/Codex/2026-06-19/opencode-web-terminal"]
+trust_level = "trusted"
+
+[projects."/Users/gen/ghq/github.com/usabarashi/openai-usage-tracker"]
+trust_level = "trusted"
+
+[projects."/Users/gen/ghq/github.com/usabarashi/nix-config"]
+trust_level = "trusted"
+
+[tui.model_availability_nux]
+"gpt-5.5" = 4

--- a/home/private/default.nix
+++ b/home/private/default.nix
@@ -26,7 +26,6 @@
   ];
 
   imports = [
-    ../../modules/darwin/karabiner.nix
     ../../modules/shared/agents-antigravity.nix
     ../../modules/shared/agents-codex.nix
     ../../modules/shared/agents-opencode.nix

--- a/home/work/default.nix
+++ b/home/work/default.nix
@@ -24,7 +24,6 @@
   ];
 
   imports = [
-    ../../modules/darwin/karabiner.nix
     ../../modules/shared/agents-antigravity.nix
     ../../modules/shared/agents-claude-code.nix
     ../../modules/shared/container.nix

--- a/hosts/mac14-10/default.nix
+++ b/hosts/mac14-10/default.nix
@@ -1,9 +1,11 @@
 { userName, ... }:
 {
   imports = [
+    ../../modules/darwin/karabiner.nix
     ../../modules/darwin/netskope-ssl.nix
     ../../modules/darwin/nix-maintenance.nix
     ../../modules/darwin/nix-settings.nix
+    ../../modules/darwin/sleepctl.nix
   ];
 
   # See: https://daiderd.com/nix-darwin/manual/
@@ -53,7 +55,6 @@
 
     keyboard = {
       enableKeyMapping = true;
-      remapCapsLockToControl = true;
     };
   };
 

--- a/hosts/mac14-9/default.nix
+++ b/hosts/mac14-9/default.nix
@@ -1,8 +1,10 @@
 { userName, ... }:
 {
   imports = [
+    ../../modules/darwin/karabiner.nix
     ../../modules/darwin/nix-maintenance.nix
     ../../modules/darwin/nix-settings.nix
+    ../../modules/darwin/sleepctl.nix
   ];
 
   # See: https://daiderd.com/nix-darwin/manual/
@@ -52,7 +54,6 @@
 
     keyboard = {
       enableKeyMapping = true;
-      remapCapsLockToControl = true;
     };
   };
 

--- a/lib/builders.nix
+++ b/lib/builders.nix
@@ -41,7 +41,11 @@
     in
     nix-darwin.lib.darwinSystem {
       specialArgs = {
-        inherit userName homeDirectory;
+        inherit
+          userName
+          homeDirectory
+          repoPath
+          ;
       };
       modules = [
         hostConfig

--- a/modules/darwin/karabiner.nix
+++ b/modules/darwin/karabiner.nix
@@ -1,12 +1,8 @@
-{
-  config,
-  repoPath,
-  ...
-}:
+{ userName, repoPath, ... }:
 
 {
-  home.file.".config/karabiner/karabiner.json" = {
-    source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/karabiner/karabiner.json";
+  home-manager.users.${userName}.home.file.".config/karabiner/karabiner.json" = {
+    source = builtins.path { path = "${repoPath}/config/karabiner/karabiner.json"; };
     force = true;
   };
 }

--- a/modules/darwin/karabiner.nix
+++ b/modules/darwin/karabiner.nix
@@ -1,8 +1,10 @@
 { userName, repoPath, ... }:
 
 {
-  home-manager.users.${userName}.home.file.".config/karabiner/karabiner.json" = {
-    source = builtins.path { path = "${repoPath}/config/karabiner/karabiner.json"; };
-    force = true;
+  home-manager.users.${userName} = { config, ... }: {
+    home.file.".config/karabiner/karabiner.json" = {
+      source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/karabiner/karabiner.json";
+      force = true;
+    };
   };
 }

--- a/modules/darwin/sleepctl.nix
+++ b/modules/darwin/sleepctl.nix
@@ -1,0 +1,116 @@
+{ pkgs, userName, ... }:
+
+let
+  # Background daemon that monitors Caps Lock state via ioreg and sets
+  # pmset disablesleep accordingly. When sleep prevention is active,
+  # it also watches the lid state and turns off the internal display
+  # on lid-close (since macOS keeps it on when disablesleep=1).
+  #   Caps Lock ON  (LED lit)   → disablesleep = 1 (sleep prevention)
+  #   Caps Lock OFF (LED off)   → disablesleep = 0 (normal sleep)
+  daemon = pkgs.writeShellScript "sleepctl-daemon" ''
+    set -u
+    last_capslock=""
+    lid_fired=0
+
+    while :; do
+      # ---- Caps Lock polling ----
+      # Read HIDCapsLockState from IOHIDSystem (returns Yes/No or true/false).
+      # This reflects the physical toggle state of the Caps Lock key.
+      capslock=$(/usr/sbin/ioreg -n IOHIDSystem -r \
+        | /usr/bin/awk -F' = ' '/HIDCapsLockState/{gsub(/[^a-zA-Z]/,"",$2); print $2; exit}')
+
+      if [ -n "$capslock" ] && [ "$capslock" != "$last_capslock" ]; then
+        if [ "$capslock" = "Yes" ] || [ "$capslock" = "true" ]; then
+          /usr/bin/sudo -n /usr/bin/pmset -a disablesleep 1 \
+            && /usr/bin/logger -t sleepctl-daemon "disablesleep=1 (caps lock on)" \
+            || /usr/bin/logger -t sleepctl-daemon "ERROR: pmset disablesleep 1 failed"
+        else
+          /usr/bin/sudo -n /usr/bin/pmset -a disablesleep 0 \
+            && /usr/bin/logger -t sleepctl-daemon "disablesleep=0 (caps lock off)" \
+            || /usr/bin/logger -t sleepctl-daemon "ERROR: pmset disablesleep 0 failed"
+        fi
+        last_capslock="$capslock"
+      fi
+
+      # ---- Lid-closed display sleep ----
+      # Only active when disablesleep=1. When the lid closes while sleep is
+      # disabled, the internal display stays on; this sends displaysleepnow
+      # once per close event to turn it off. No-op when disablesleep=0.
+      disabled=$(/usr/bin/pmset -g | /usr/bin/awk '$1 == "SleepDisabled" { print $2; exit }')
+
+      if [ "$disabled" = "1" ]; then
+        state=$(/usr/sbin/ioreg -r -k AppleClamshellState -d 1 \
+          | /usr/bin/awk -F' = ' '$1 ~ /"AppleClamshellState"$/ { gsub(/[^a-zA-Z]/,"",$2); print $2; exit }')
+
+        if [ "$state" = "Yes" ] || [ "$state" = "true" ]; then
+          if [ "$lid_fired" = "0" ]; then
+            /usr/bin/pmset displaysleepnow \
+              && /usr/bin/logger -t sleepctl-daemon "display sleep (lid closed)" \
+              || /usr/bin/logger -t sleepctl-daemon "ERROR: pmset displaysleepnow failed"
+            lid_fired=1
+          fi
+        else
+          lid_fired=0
+        fi
+      else
+        lid_fired=0
+      fi
+
+      /bin/sleep 0.25
+    done
+  '';
+
+  # Read-only CLI to check current disablesleep status from anywhere
+  # (not just zsh), since the physical Caps Lock key is the only
+  # control surface. Use -v or --verbose to show raw ioreg values.
+  sleepctlCmd = pkgs.writeShellScriptBin "sleepctl" ''
+    case "$1" in
+      -v|--verbose)
+        verbose=1
+        shift
+        ;;
+      status)
+        verbose=0
+        ;;
+      *)
+        echo "usage: sleepctl status [-v|--verbose]" >&2
+        exit 1
+        ;;
+    esac
+
+    disabled=$(/usr/bin/pmset -g | /usr/bin/awk "\$1 == \"SleepDisabled\" { print \$2; exit }")
+    if [ "$disabled" = "1" ]; then
+      echo "on"
+    else
+      echo "off"
+    fi
+
+    if [ "$verbose" = "1" ]; then
+      capslock=$(/usr/sbin/ioreg -n IOHIDSystem -r \
+        | /usr/bin/awk -F" = " "/HIDCapsLockState/{gsub(/[^a-zA-Z]/,\"\",\$2); print \$2; exit}")
+      clamshell=$(/usr/sbin/ioreg -r -k AppleClamshellState -d 1 \
+        | /usr/bin/awk -F" = " "\$1 ~ /\"AppleClamshellState\"\$/ { gsub(/[^a-zA-Z]/,\"\",\$2); print \$2; exit }")
+      echo "capslock_raw: $capslock"
+      echo "clamshell_raw: $clamshell"
+    fi
+  '';
+in
+{
+  # Install the sleepctl CLI into system PATH (available to all shells).
+  environment.systemPackages = [ sleepctlCmd ];
+
+  # Passwordless sudo for the daemon's pmset disablesleep commands.
+  # Arguments are restricted to exact matches for disablesleep 1/0 only.
+  security.sudo.extraConfig = ''
+    ${userName} ALL=(root) NOPASSWD: /usr/bin/pmset -a disablesleep 1, /usr/bin/pmset -a disablesleep 0
+  '';
+
+  launchd.user.agents.sleepctl-daemon = {
+    serviceConfig = {
+      ProgramArguments = [ "${daemon}" ];
+      RunAtLoad = true;
+      KeepAlive = true;
+      ProcessType = "Background";
+    };
+  };
+}

--- a/modules/darwin/sleepctl.nix
+++ b/modules/darwin/sleepctl.nix
@@ -12,6 +12,12 @@ let
     last_capslock=""
     lid_fired=0
 
+    # Read initial state once; track it locally to avoid polling pmset -g
+    # every 250ms in the loop below.
+    sleep_disabled=$(/usr/bin/pmset -g \
+      | /usr/bin/awk '$1 == "SleepDisabled" { print $2; exit }')
+    [ "$sleep_disabled" = "1" ] || sleep_disabled=0
+
     while :; do
       # ---- Caps Lock polling ----
       # Read HIDCapsLockState from IOHIDSystem (returns Yes/No or true/false).
@@ -22,23 +28,22 @@ let
       if [ -n "$capslock" ] && [ "$capslock" != "$last_capslock" ]; then
         if [ "$capslock" = "Yes" ] || [ "$capslock" = "true" ]; then
           /usr/bin/sudo -n /usr/bin/pmset -a disablesleep 1 \
-            && /usr/bin/logger -t sleepctl-daemon "disablesleep=1 (caps lock on)" \
+            && { /usr/bin/logger -t sleepctl-daemon "disablesleep=1 (caps lock on)"; sleep_disabled=1; } \
             || /usr/bin/logger -t sleepctl-daemon "ERROR: pmset disablesleep 1 failed"
         else
           /usr/bin/sudo -n /usr/bin/pmset -a disablesleep 0 \
-            && /usr/bin/logger -t sleepctl-daemon "disablesleep=0 (caps lock off)" \
+            && { /usr/bin/logger -t sleepctl-daemon "disablesleep=0 (caps lock off)"; sleep_disabled=0; } \
             || /usr/bin/logger -t sleepctl-daemon "ERROR: pmset disablesleep 0 failed"
         fi
         last_capslock="$capslock"
       fi
 
       # ---- Lid-closed display sleep ----
-      # Only active when disablesleep=1. When the lid closes while sleep is
-      # disabled, the internal display stays on; this sends displaysleepnow
-      # once per close event to turn it off. No-op when disablesleep=0.
-      disabled=$(/usr/bin/pmset -g | /usr/bin/awk '$1 == "SleepDisabled" { print $2; exit }')
-
-      if [ "$disabled" = "1" ]; then
+      # Uses local sleep_disabled variable instead of polling pmset -g
+      # each iteration. Since this daemon is the sole controller of
+      # disablesleep, the variable stays in sync. Only when Caps Lock
+      # is toggled externally would it drift — unlikely in practice.
+      if [ "$sleep_disabled" = "1" ]; then
         state=$(/usr/sbin/ioreg -r -k AppleClamshellState -d 1 \
           | /usr/bin/awk -F' = ' '$1 ~ /"AppleClamshellState"$/ { gsub(/[^a-zA-Z]/,"",$2); print $2; exit }')
 
@@ -64,19 +69,29 @@ let
   # (not just zsh), since the physical Caps Lock key is the only
   # control surface. Use -v or --verbose to show raw ioreg values.
   sleepctlCmd = pkgs.writeShellScriptBin "sleepctl" ''
-    case "$1" in
-      -v|--verbose)
-        verbose=1
-        shift
-        ;;
-      status)
-        verbose=0
-        ;;
-      *)
-        echo "usage: sleepctl status [-v|--verbose]" >&2
-        exit 1
-        ;;
-    esac
+    verbose=0
+    action=""
+
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -v|--verbose)
+          verbose=1
+          ;;
+        status)
+          action="status"
+          ;;
+        *)
+          echo "usage: sleepctl status [-v|--verbose]" >&2
+          exit 1
+          ;;
+      esac
+      shift
+    done
+
+    if [ "$action" != "status" ]; then
+      echo "usage: sleepctl status [-v|--verbose]" >&2
+      exit 1
+    fi
 
     disabled=$(/usr/bin/pmset -g | /usr/bin/awk "\$1 == \"SleepDisabled\" { print \$2; exit }")
     if [ "$disabled" = "1" ]; then


### PR DESCRIPTION


## Why

Running AI agents (Claude Code, Codex), SSH sessions, or long builds with the lid
closed requires `pmset -a disablesleep 1`, but toggling it via CLI is easy to
forget and provides no physical confirmation. The existing Caps Lock → Control
remap was only avoiding accidental Caps Lock presses — a waste of a physical LED
that could serve as a status indicator.

## What

Replace Caps Lock's Control remap with a sleep-prevention switch. A launchd
user agent polls the Caps Lock state via ioreg every 250ms; on state change it
runs `sudo -n pmset -a disablesleep 1/0` through a passwordless sudoers rule
restricted to exact commands. When sleep prevention is active and the lid closes,
the same agent sends `pmset displaysleepnow` to turn off the internal display
(macOS keeps it on during disablesleep). A read-only `sleepctl status` CLI is
available via `environment.systemPackages` for remote checking; `-v` shows raw
ioreg values for debugging.

This replaces a third-party GUI app (Capsomnia) with a declarative, self-contained
Nix module, and frees the Home Row's most accessible physical key from a
defensive remap to a purposeful one.

Along the way, karabiner.nix was moved from the home-manager import tree to the
nix-darwin import tree, and refactored to use `home-manager.users.<name>.home.file`
instead of the top-level `home.file` — aligning with the principle that
`modules/darwin/` holds all macOS-specific configuration regardless of module
system. `repoPath` was added to nix-darwin's `specialArgs` in `lib/builders.nix`
to support this.

Trade-off accepted: when Caps Lock is ON, keyboard input produces UPPERCASE.
The typical workflow (turn ON → close lid → open lid → turn OFF) avoids this
in practice.

## References

N/A
