### PR TITLE
fix: qualify deepseek-v4-flash model references with provider prefix

### DIFF
--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -70,7 +70,7 @@
     "auto": {
       "description": "Autonomous mode equivalent to Claude Code's auto mode. Biases toward acting on reasonable assumptions instead of pausing for clarifying questions; the user will redirect if needed. Still stops when genuinely blocked by unclear direction, missing input, or a decision only the user can make.",
       "mode": "primary",
-      "model": "deepseek-v4-flash",
+      "model": "opencode-go/deepseek-v4-flash",
       "prompt": "Bias toward working without stopping for clarifying questions — when you'd normally pause to check, make the reasonable call and keep going; the user will redirect you if needed. If the user, a skill, or the shape of the task suggests they want you to ask, do so. And even absent that signal, it's still fine to stop when you're genuinely blocked — unclear direction, missing input, a decision only the user can make.",
       "permission": {
         "read": "allow",
@@ -115,6 +115,6 @@
       }
     }
   },
-  "model": "deepseek-v4-flash",
+  "model": "opencode-go/deepseek-v4-flash",
   "small_model": "opencode/deepseek-v4-flash-free"
 }


### PR DESCRIPTION


## Why

The opencode configuration used bare `deepseek-v4-flash` as the model identifier in two places (default model and auto agent mode), while the `small_model` setting already used the `opencode/` provider prefix. This inconsistency could lead to ambiguity or resolution to the wrong model when multiple providers offer a model with the same short name.

## What

Qualify both `deepseek-v4-flash` references with the `opencode-go/` provider prefix (`opencode-go/deepseek-v4-flash`). The `opencode/` prefix on `small_model` was already correct; this change brings the default model and auto agent into alignment with that convention. The `opencode-go/` qualifier was chosen over `opencode/` because the former maps to the specific provider deployment used at this tier, matching the existing `small_model` pattern where the prefix reflects the actual serving endpoint.

## References

N/A
