### PR TITLE
Add reviewer subagent and wire config/claude/agents syncing

### DIFF
--- a/config/claude/agents/reviewer.md
+++ b/config/claude/agents/reviewer.md
@@ -1,0 +1,10 @@
+---
+name: reviewer
+description: Specialist agent for reviewing code quality, security, and design. Always use after completing an implementation.
+tools: Read, Grep, Glob
+model: claude-opus-4-8
+---
+
+You are a senior reviewer. Review code rigorously for quality, security, and maintainability, and report findings by priority (Critical / Warning / Suggestion).
+
+You are read-only: never modify, create, or delete files, and never run commands. Inspect only the files and diffs given to you or discoverable via Read/Grep/Glob.

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -190,6 +190,7 @@
     ],
     "defaultMode": "auto"
   },
+  "model": "claude-sonnet-5",
   "hooks": {
     "PreToolUse": [
       {
@@ -258,10 +259,9 @@
   },
   "tui": "fullscreen",
   "voice": {
-    "enabled": false,
+    "enabled": true,
     "mode": "hold"
   },
   "skipAutoPermissionPrompt": true,
-  "voiceEnabled": false,
-  "model": "claude-opus-4-7"
+  "voiceEnabled": true
 }

--- a/modules/shared/agents-claude-code.nix
+++ b/modules/shared/agents-claude-code.nix
@@ -7,6 +7,13 @@
 }:
 
 let
+  # Claude-specific (unlike the config/agents/* bindings below), mirrors how
+  # CLAUDE.md and settings.json are sourced from config/claude/ in this file.
+  claudeAgents = {
+    source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/claude/agents";
+    force = true;
+    recursive = true;
+  };
   agentScripts = {
     source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/agents/scripts";
     force = true;
@@ -49,6 +56,7 @@ in
       source = config.lib.file.mkOutOfStoreSymlink "${repoPath}/config/claude/settings.json";
       force = true;
     };
+    ".claude/agents" = claudeAgents;
     ".claude/commands" = agentCommands;
     ".claude/scripts" = agentScripts;
     ".claude/skills" = agentSkills;


### PR DESCRIPTION


## Why
There was a dedicated need for a code-review subagent to run after implementation work, but `modules/shared/agents-claude-code.nix` only synced commands, scripts, and skills from `config/claude/` into `~/.claude/` — custom agent definitions had no delivery path. The default `settings.json` was also still pinned to the superseded `claude-opus-4-7` model and shipped with voice input off.

## What
- Defined the reviewer as a restricted subagent (`Read`, `Grep`, `Glob` only, pinned to `claude-opus-4-8`) rather than a general-purpose one, so it can be invoked automatically after implementation steps without risking file mutations or command execution during review.
- Added a `claudeAgents` file binding in `agents-claude-code.nix` for `.claude/agents`, following the same out-of-store-symlink pattern already used for commands, scripts, and skills, so agent definitions in `config/claude/agents/` stay live-editable without a rebuild per change.
- Moved default `settings.json` off `claude-opus-4-7` onto `claude-sonnet-5` and turned on `voice.enabled`/`voiceEnabled`, aligning the shipped defaults with the model and input mode now actually in use.

## References
N/A
