### PR TITLE
Update Claude Code, Codex, opencode, and Antigravity CLI binaries

### DIFF
--- a/packages/antigravity-cli-bin/default.nix
+++ b/packages/antigravity-cli-bin/default.nix
@@ -10,13 +10,13 @@
 # https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/darwin_arm64.json
 # Pinned here so `agy update` cannot drift the store path out from under Nix.
 let
-  version = "1.0.16";
+  version = "1.1.5";
   # GCS build ID appended to the version in the bucket path; published alongside
   # `version` in the auto-updater manifest and bumped together with it.
-  buildId = "4893150192467968";
+  buildId = "5958982624477184";
   src = fetchurl {
     url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${version}-${buildId}/darwin-arm/cli_mac_arm64.tar.gz";
-    hash = "sha512-mCUJnai4+TtYnRfp08FEvogiPZY0GyILSDt9iBhE9gcDkmO9I/ovAqmgOX7XS1ZjTa3Iw0rqu6tFyut8NMjX8w==";
+    hash = "sha512-1OM/UqvYpP0JTsOhKzG7G2V8pPsrn4qndAxA/kf1dSZ+sKJNNSY/3dQCdXUBNnAAHJX21cI/39/CzlCYbcY4xA==";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/claude-code-bin/default.nix
+++ b/packages/claude-code-bin/default.nix
@@ -7,10 +7,10 @@
   stdenvNoCC,
 }:
 let
-  version = "2.1.200";
+  version = "2.1.206";
   src = fetchurl {
     url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${version}/darwin-arm64/claude";
-    hash = "sha256-5v1SwMcv+DZjvzy/yDO0X6q6K5qZUoYyedw8/BoEkrY=";
+    hash = "sha256-MZerpEQtvVs99CtvNebXvQO15Izhi3o8XG9fjCjgO38=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/codex-bin/default.nix
+++ b/packages/codex-bin/default.nix
@@ -7,11 +7,11 @@
   stdenvNoCC,
 }:
 let
-  version = "0.142.5";
+  version = "0.145.0";
   asset = "codex-aarch64-apple-darwin";
   src = fetchurl {
     url = "https://github.com/openai/codex/releases/download/rust-v${version}/${asset}.tar.gz";
-    hash = "sha256-cVaxmWJzXJz7VVzde6voxA55dogfhxK3gRmSGdLjpwc=";
+    hash = "sha256-Byowpl8FZmc1iJ7w9gtW2xhq293p1cXMGmS+C1mFMP4=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/opencode-bin/default.nix
+++ b/packages/opencode-bin/default.nix
@@ -9,11 +9,11 @@
   unzip,
 }:
 let
-  version = "1.17.13";
+  version = "1.18.4";
   asset = "opencode-darwin-arm64";
   src = fetchurl {
     url = "https://github.com/sst/opencode/releases/download/v${version}/${asset}.zip";
-    hash = "sha256-3QFtPiazR9Z1qybEXR4odUWRLVxMSfoHcLYi1KE2fiM=";
+    hash = "sha256-BPuIG2MrMjxxLf2m3LvG/Oc2OU8HunYXblLWZlkl1OY=";
   };
 in
 stdenvNoCC.mkDerivation {


### PR DESCRIPTION


## Why
The four coding-agent CLIs are pinned to fixed versions in `packages/*-bin/default.nix` because they are fetched independently of nixpkgs (which lags or doesn't package them). These pins had drifted well behind upstream: Claude Code (2.1.200), Codex (0.142.5), opencode (1.17.13), and Antigravity CLI (1.0.16) were all several releases behind their respective latest stable releases.

## What
Bumped `version` (and `buildId` for Antigravity, which encodes the GCS build path) and re-fetched the corresponding `hash` for each of the four packages, using each project's official release channel as the source of truth (GitHub Releases for Codex/opencode, GCS release bucket for Claude Code, the GCS auto-updater manifest for Antigravity). Verified by building each of the four derivations directly (not just `--dry-run`) on both `mac14-9` and `mac14-10` darwin configurations to confirm the fixed-output hashes match the fetched content before committing. `modules/shared/agents-*.nix` were left untouched since they only wire in these packages by name and carry no version information themselves.

## References
N/A
