### PR TITLE
Fix /advisor being unrecognized by unblocking feature-flag traffic

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -5,7 +5,6 @@
     "BASH_MAX_TIMEOUT_MS": "1200000",
     "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1",
     "CLAUDE_CODE_DISABLE_LOCATION": "1",
-    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_SUBPROCESS_ENV_SCRUB": "1",
     "DISABLE_AUTOUPDATER": "1",
@@ -191,6 +190,7 @@
     "defaultMode": "auto"
   },
   "model": "claude-sonnet-5",
+  "advisorModel": "opus",
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION


## Why
`/advisor` (Claude Code's Advisor Tool) returned `Unknown command: /advisor` even though the feature has shipped since v2.1.117 and the pinned binary, model, and settings were otherwise compatible. `claude doctor` traced the cause to `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`: it disables the feature-flag evaluation traffic that experimental features (Advisor Tool, Remote Control) depend on to register themselves, so the slash command never appears regardless of local config.

## What
- Removed `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` outright rather than looking for a narrower toggle — Claude Code doesn't expose a way to keep telemetry off while still allowing feature-flag fetches, so keeping the setting and the advisor tool working are mutually exclusive.
- Added `"advisorModel": "opus"` so the advisor is pre-configured once the flag unlocks `/advisor`, pairing Opus with the main `claude-sonnet-5` model per Claude Code's documented model-pairing rules.
- Left `CLAUDE_CODE_DISABLE_ADVISOR_TOOL` untouched — Claude Code's own docs define it as a value check (only `"1"` disables), so a `"0"` override investigated earlier is a no-op and isn't needed here.

## References
N/A
