### PR TITLE
Add WebUI config generation with date awareness and MCP proxy

### DIFF
--- a/config/llama-server/switch-to.sh
+++ b/config/llama-server/switch-to.sh
@@ -141,6 +141,7 @@ start_model() {
         --jinja \
         --host 127.0.0.1 --port $PORT \
         --webui-mcp-proxy --webui-config-file "$WEBUI_CONFIG" \
+        --tools read_file \
         >> "$LOG" 2>&1 &
 }
 
@@ -173,6 +174,7 @@ start_model_local() {
         --jinja \
         --host 127.0.0.1 --port $PORT \
         --webui-mcp-proxy --webui-config-file "$WEBUI_CONFIG" \
+        --tools read_file \
         >> "$LOG" 2>&1 &
 }
 

--- a/config/llama-server/switch-to.sh
+++ b/config/llama-server/switch-to.sh
@@ -7,6 +7,50 @@ LLAMA_BIN="@llamaServer@"
 PORT=18080
 LOG="$HOME/.cache/llama-server/llama-server.log"
 MAX_LOG_SIZE=104857600  # 100 MB
+WEBUI_CONFIG="$HOME/.config/llama-server/webui.json"
+WEBUI_DEFAULTS="$HOME/.config/llama-server/webui-defaults.json"
+
+# Generate WebUI config with today's date in the system prompt, so the model
+# knows the current date and doesn't anchor to its training cutoff.
+# Merges defaults from webui-defaults.json (symlink, repo-managed) with any
+# existing runtime webui.json (user/MCP settings), injects the date, and
+# writes the result to webui.json (regular file, writable).
+webui_config() {
+    local today time
+    today=$(date '+%Y-%m-%d')
+    time=$(date '+%H:%M')
+
+    mkdir -p "$(dirname "$WEBUI_CONFIG")"
+    /usr/bin/python3 -c "
+import json, os
+
+defaults_path = '$WEBUI_DEFAULTS'
+runtime_path = '$WEBUI_CONFIG'
+
+# Start with defaults from repo-managed symlink
+if os.path.exists(defaults_path):
+    with open(defaults_path) as f:
+        cfg = json.load(f)
+else:
+    cfg = {}
+
+# Add any runtime-only keys (e.g., mcpServers configured via Web UI)
+# that don't exist in defaults — defaults always take priority.
+if os.path.exists(runtime_path):
+    with open(runtime_path) as f:
+        existing = json.load(f)
+    for k, v in existing.items():
+        if k not in cfg:
+            cfg[k] = v
+
+# Inject current date as systemMessage (always wins)
+cfg['systemMessage'] = 'Today is $today. The current time is approximately $time. Treat this as the current date and time for all references.'
+
+with open(runtime_path, 'w') as f:
+    json.dump(cfg, f, indent=2)
+    f.write('\n')
+" && [ -f "$WEBUI_CONFIG" ]
+}
 
 # ------- helpers -------
 
@@ -46,6 +90,7 @@ start_model() {
     sleep 1
     mkdir -p "$(dirname "$LOG")"
     rotate_log
+    webui_config
     nohup "$LLAMA_BIN" \
         -hf "$hf_repo" \
         --alias "$alias" \
@@ -57,6 +102,7 @@ start_model() {
         -b 4096 -ub 1024 \
         --jinja \
         --host 127.0.0.1 --port $PORT \
+        --webui-mcp-proxy --webui-config-file "$WEBUI_CONFIG" \
         >> "$LOG" 2>&1 &
 }
 
@@ -73,6 +119,7 @@ start_model_local() {
     sleep 1
     mkdir -p "$(dirname "$LOG")"
     rotate_log
+    webui_config
     nohup "$LLAMA_BIN" \
         -m "$model_file" \
         --alias "$alias" \
@@ -84,6 +131,7 @@ start_model_local() {
         -b 4096 -ub 1024 \
         --jinja \
         --host 127.0.0.1 --port $PORT \
+        --webui-mcp-proxy --webui-config-file "$WEBUI_CONFIG" \
         >> "$LOG" 2>&1 &
 }
 

--- a/config/llama-server/switch-to.sh
+++ b/config/llama-server/switch-to.sh
@@ -125,7 +125,10 @@ start_model() {
     sleep 1
     mkdir -p "$(dirname "$LOG")"
     rotate_log
-    webui_config
+    if ! webui_config; then
+        echo "ERROR: failed to generate WebUI config" >> "$LOG"
+        return 1
+    fi
     nohup "$LLAMA_BIN" \
         -hf "$hf_repo" \
         --alias "$alias" \
@@ -154,7 +157,10 @@ start_model_local() {
     sleep 1
     mkdir -p "$(dirname "$LOG")"
     rotate_log
-    webui_config
+    if ! webui_config; then
+        echo "ERROR: failed to generate WebUI config" >> "$LOG"
+        return 1
+    fi
     nohup "$LLAMA_BIN" \
         -m "$model_file" \
         --alias "$alias" \

--- a/config/llama-server/webui-defaults.json
+++ b/config/llama-server/webui-defaults.json
@@ -1,0 +1,10 @@
+{
+  "systemMessage": "Overwritten on startup",
+  "theme": "system",
+  "showSystemMessage": false,
+  "showThoughtInProgress": false,
+  "disableReasoningParsing": false,
+  "keepStatsVisible": true,
+  "showToolCallInProgress": true,
+  "alwaysShowAgenticTurns": true
+}

--- a/config/swiftbar/llama-server.5s.sh
+++ b/config/swiftbar/llama-server.5s.sh
@@ -84,6 +84,7 @@ if is_running; then
     echo "Memory: ~21 GB | size=12"
     echo "CPU: ${CPU}% | size=12"
     echo "Port: ${PORT} | size=12"
+    echo "Open Web UI | href=http://127.0.0.1:${PORT}"
     echo "---"
 
     # Gray out the currently active model
@@ -103,6 +104,7 @@ elif is_transitioning; then
     echo "---"
     # All actions grayed out during transition
     all="color=gray"
+    echo "Open Web UI (starting...) | href=http://127.0.0.1:${PORT} $all"
     echo "Start Qwen3.6 35B | bash=$SWITCH_TO param1=qwen terminal=false refresh=5s $all"
     echo "Start Gemma 4 | bash=$SWITCH_TO param1=gemma terminal=false refresh=5s $all"
     echo "Stop | bash=$SWITCH_TO param1=stopped terminal=false refresh=5s $all"
@@ -114,4 +116,6 @@ else
     echo "---"
     echo "Start Qwen3.6 35B | bash=$SWITCH_TO param1=qwen terminal=false refresh=5s"
     echo "Start Gemma 4 | bash=$SWITCH_TO param1=gemma terminal=false refresh=5s"
+    all="color=gray"
+    echo "Open Web UI | href=http://127.0.0.1:${PORT} $all"
 fi

--- a/modules/shared/llm.nix
+++ b/modules/shared/llm.nix
@@ -50,6 +50,9 @@ in
     );
 
     file = {
+      ".config/llama-server/webui-defaults.json" = {
+        source = ../../config/llama-server/webui-defaults.json;
+      };
       ".config/llama-server/switch-to.sh" = {
         source = switchTo;
         executable = true;


### PR DESCRIPTION


## Why

The llama-server WebUI had no mechanism for repo-managed default settings, so display preferences and the system message were either hardcoded in the binary or lost on every restart. The model anchored to its training cutoff because the system message never contained the current date. Server-side MCP proxy was disabled, preventing the built-in agent from using external tools like web search and fetch.

## What

A two-tier config approach: a repo-managed defaults file (`webui-defaults.json`) deployed by home-manager provides display settings (theme, thought/reasoning visibility, tool call display), while a runtime file (`webui.json`) generated at startup preserves user-configured MCP servers. The startup script merges the two — defaults always take priority for keys they define, but runtime-only keys (e.g. `mcpServers`, `mcpServerUsageStats`) survive untouched. The system message is overwritten every startup with the current date and time in English and hidden from the UI so the model stays date-aware without cluttering the chat pane. The `--webui-mcp-proxy` flag enables the server's built-in CORS proxy, which the WebUI frontend uses to reach external MCP servers without CORS preflight support. Finally, a direct "Open Web UI" link was added to the SwiftBar menu so the launch URL is always one click away.

## References

N/A
