### PR TITLE
Update AI agent binaries and serena to latest versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -251,11 +251,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1781621781,
-        "narHash": "sha256-KIF+P5bBhoYo6MhLUz2HpLD7HCXra3AYUoftdWwEHkw=",
+        "lastModified": 1785401039,
+        "narHash": "sha256-GKuqZueDX2oewucKUhN4q/0Y36THDrc9Ex89mEHpIZE=",
         "owner": "oraios",
         "repo": "serena",
-        "rev": "dd7eb6d72ae179aa940e50cd6276ec5646f306f8",
+        "rev": "dd12fa032f473a53595763b8d731817e19c15475",
         "type": "github"
       },
       "original": {

--- a/packages/antigravity-cli-bin/default.nix
+++ b/packages/antigravity-cli-bin/default.nix
@@ -10,13 +10,13 @@
 # https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/darwin_arm64.json
 # Pinned here so `agy update` cannot drift the store path out from under Nix.
 let
-  version = "1.1.5";
+  version = "1.1.8";
   # GCS build ID appended to the version in the bucket path; published alongside
   # `version` in the auto-updater manifest and bumped together with it.
-  buildId = "5958982624477184";
+  buildId = "5636713813508096";
   src = fetchurl {
     url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${version}-${buildId}/darwin-arm/cli_mac_arm64.tar.gz";
-    hash = "sha512-1OM/UqvYpP0JTsOhKzG7G2V8pPsrn4qndAxA/kf1dSZ+sKJNNSY/3dQCdXUBNnAAHJX21cI/39/CzlCYbcY4xA==";
+    hash = "sha512-S8Jk59xnDSOLYqv3D3LzsN1O5m8VyWsWD6LTpt4OAvbLllhhM3c1/X/PoiFUnjTuTlj50RMrRPL64LQggWhmSQ==";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/chrome-devtools-mcp/default.nix
+++ b/packages/chrome-devtools-mcp/default.nix
@@ -31,10 +31,10 @@
   makeWrapper,
 }:
 let
-  version = "1.2.0";
+  version = "1.6.0";
   src = fetchurl {
     url = "https://registry.npmjs.org/chrome-devtools-mcp/-/chrome-devtools-mcp-${version}.tgz";
-    hash = "sha256-r2qGlCRLSzDbSAM8sOClDBO7cIZkSEcJn571zHYgigU=";
+    hash = "sha512-VZX6f/OjQSYhy2BGGRs+y3LsrsAQAz/HwZCWKBLVyST/4r/3zjVEjjVW7gMCVbRDuspnVdcp5hQDPrQ5UFrdZw==";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/claude-code-bin/default.nix
+++ b/packages/claude-code-bin/default.nix
@@ -7,10 +7,10 @@
   stdenvNoCC,
 }:
 let
-  version = "2.1.206";
+  version = "2.1.220";
   src = fetchurl {
     url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${version}/darwin-arm64/claude";
-    hash = "sha256-MZerpEQtvVs99CtvNebXvQO15Izhi3o8XG9fjCjgO38=";
+    hash = "sha256-it3IV/P+ZNWgNor57lAyG1CvtKaRi6PvAYq4T1274IE=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/codex-bin/default.nix
+++ b/packages/codex-bin/default.nix
@@ -7,11 +7,11 @@
   stdenvNoCC,
 }:
 let
-  version = "0.145.0";
+  version = "0.146.0";
   asset = "codex-aarch64-apple-darwin";
   src = fetchurl {
     url = "https://github.com/openai/codex/releases/download/rust-v${version}/${asset}.tar.gz";
-    hash = "sha256-Byowpl8FZmc1iJ7w9gtW2xhq293p1cXMGmS+C1mFMP4=";
+    hash = "sha256-J1ATLTAOZPHb/7lePZE/2cnceBK8jhvOXGE1cki3kp4=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/opencode-bin/default.nix
+++ b/packages/opencode-bin/default.nix
@@ -9,11 +9,11 @@
   unzip,
 }:
 let
-  version = "1.18.4";
+  version = "1.18.10";
   asset = "opencode-darwin-arm64";
   src = fetchurl {
     url = "https://github.com/sst/opencode/releases/download/v${version}/${asset}.zip";
-    hash = "sha256-BPuIG2MrMjxxLf2m3LvG/Oc2OU8HunYXblLWZlkl1OY=";
+    hash = "sha256-ZB/i5l5C23bC0y21+FVzw2gqjHL4LQFWipIqj+zMRlg=";
   };
 in
 stdenvNoCC.mkDerivation {


### PR DESCRIPTION


## Why
The agent CLIs (Antigravity, Claude Code, Codex, opencode) are distributed as closed-source/prebuilt binaries that self-update by design, but this repo pins each one to a fixed store-path artifact so the installed version cannot drift out from under Nix. Those pins had fallen behind upstream — several minor releases each — leaving known fixes and features unshipped. Since the pins defeat upstream auto-updaters, bumping them is a deliberate, manual maintenance step that must be redone periodically.

## What
The update follows each upstream's canonical release channel rather than trusting a single source: the Antigravity CLI auto-updater manifest (the only place version, GCS build ID, and sha512 are published together), GitHub release asset digests for Codex and opencode, the npm registry integrity hash for Chrome DevTools MCP, and a hash computed directly from the downloaded artifact for Claude Code (which has no manifest). The Chrome DevTools MCP pin also switched from sha256 to the registry's sha512 integrity value, matching what npm itself verifies against. The serena flake input was refreshed alongside the binaries since it is the MCP server dependency; voicevox-cli was already at its latest revision and was left untouched. All five rebuilt packages were verified locally before committing, so the committed hashes match what a fresh fetch produces rather than being left for CI to discover.

## References
N/A
