### PR TITLE
fix: correct model references in opencode configuration

### DIFF
--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -79,7 +79,7 @@
     "auto": {
       "description": "Autonomous mode equivalent to Claude Code's auto mode. Biases toward acting on reasonable assumptions instead of pausing for clarifying questions; the user will redirect if needed. Still stops when genuinely blocked by unclear direction, missing input, or a decision only the user can make.",
       "mode": "primary",
-      "model": "opencode-go/deepseek-v4-flash",
+      "model": "opencode/deepseek-v4-flash",
       "prompt": "Bias toward working without stopping for clarifying questions — when you'd normally pause to check, make the reasonable call and keep going; the user will redirect you if needed. If the user, a skill, or the shape of the task suggests they want you to ask, do so. And even absent that signal, it's still fine to stop when you're genuinely blocked — unclear direction, missing input, a decision only the user can make.",
       "permission": {
         "read": "allow",
@@ -99,7 +99,7 @@
     "review": {
       "description": "Read-only code reviewer. Inspect the current git diff first, then read touched files as needed. Flag correctness risks, regressions, security issues, and missing tests. Do not edit files.",
       "mode": "subagent",
-      "model": "opencode-go/kimi-k2.7-code",
+      "model": "opencode-go/kimi-k3",
       "steps": 8,
       "temperature": 0.1,
       "permission": {
@@ -124,6 +124,6 @@
       }
     }
   },
-  "model": "opencode-go/deepseek-v4-flash",
-  "small_model": "opencode/deepseek-v4-flash-free"
+  "model": "opencode/deepseek-v4-flash",
+  "small_model": "llamacpp-local/qwen3.6-35b-a3b"
 }


### PR DESCRIPTION


## Why
The opencode-go provider is being phased out, making `opencode-go/` model references invalid. The free-tier small model (`opencode/deepseek-v4-flash-free`) was unreliable for lightweight tasks, and the review agent was still on an older kimi model version.

## What
Migrated the auto agent and default model from `opencode-go/deepseek-v4-flash` to `opencode/deepseek-v4-flash` to match the active provider. Updated the review subagent to `kimi-k3` for the latest model improvements. Replaced the free-tier small model with a locally-hosted `llamacpp-local/qwen3.6-35b-a3b`, eliminating API dependency and latency for lightweight operations like title generation while also enabling offline use.

## References
N/A
