### PR TITLE
Improve codex-second-opinion skill with model pinning and instruction clarity

### DIFF
--- a/config/agents/skills/codex-second-opinion/SKILL.md
+++ b/config/agents/skills/codex-second-opinion/SKILL.md
@@ -25,28 +25,30 @@ Provide your independent analysis. If you disagree with the current approach, ex
 
 2. Run Codex CLI. Always set `sandbox_mode="danger-full-access"` (nested sandbox-exec is prohibited on macOS):
 
-**Pre-choose the output path yourself** (used by both code branches below). Pick a unique literal filesystem path in advance — e.g., `/tmp/codex-opinion-<unix-timestamp>-<random>.log`, assembled in your working context (not via `mktemp` inside the snippet, because that binds the path to a shell variable you cannot retrieve later). Reuse the exact same literal path verbatim in the Bash invocation and in the follow-up `Read`. This avoids any dependency on a harness-specific output-capture tool (`BashOutput`, task output files, etc.).
+**Pre-choose the output path yourself** (used by both code branches below). Pick a unique literal filesystem path in advance — e.g., assemble `/tmp/codex-opinion-<unix-timestamp>-<random>.log` using your host language (e.g. Python f-string or shell arithmetic, not `mktemp` inside the snippet, because that binds the path to a shell variable you cannot retrieve later). Example concrete path: `/tmp/codex-opinion-1722654321-12345.log`. Reuse the exact same literal path verbatim in the Bash invocation and in the follow-up `Read`. This avoids any dependency on a harness-specific output-capture tool (`BashOutput`, task output files, etc.).
+
+**Model pinning:** `gpt-5.6-sol` is pinned for reproducibility. If Codex CLI's default model changes (e.g., `gpt-5.7-sol` ships), the pinned model continues working but may become stale — update this skill's model string when a new generation is confirmed stable in your environment.
 
 **If Bash supports `run_in_background: true`** (typical case):
 ```bash
 # Bash tool: run_in_background: true, timeout: 300000
 # Substitute <TMPFILE> with the literal path you chose above.
-codex -c 'sandbox_mode="danger-full-access"' exec - > <TMPFILE> 2>&1 <<'CODEX_PROMPT'
+codex -c 'sandbox_mode="danger-full-access"' -c 'model="gpt-5.6-sol"' exec - > <TMPFILE> 2>&1 <<'CODEX_PROMPT'
 <constructed prompt>
 CODEX_PROMPT
 ```
-Wait for the background task to finish, then `Read <TMPFILE>`. Do NOT add `sleep` / `kill -0` / `pgrep` poll loops — they burn tool-call budget and the harness's completion signal is authoritative. An interim `Read` "to peek at progress" is also unnecessary; the file is incomplete until Codex exits. **If you are a nested subagent** (running inside an Agent/Task tool), do NOT use this background path — a subagent that ends its turn while Codex is still running will lose the background task. Use the foreground fallback below instead. After reading, `rm <TMPFILE>`; if the harness denies `rm`, leave the file — `/tmp` is reclaimed by the OS. `TaskOutput` is for Agent/Task tool tasks — do not use it here.
+Wait for the background task to finish, then `Read <TMPFILE>`. Do NOT add `sleep` / `kill -0` / `pgrep` / `$!` poll loops — they burn tool-call budget and the harness's completion signal is authoritative. An interim `Read` "to peek at progress" is also unnecessary; the file is incomplete until Codex exits. **If you are a nested subagent** (running inside an Agent/Task tool), do NOT use this background path — a subagent that ends its turn while Codex is still running will lose the background task. Use the foreground fallback below instead. After reading, `rm <TMPFILE>`; if the harness denies `rm`, leave the file — `/tmp` is reclaimed by the OS. `TaskOutput` is for Agent/Task tool tasks — do not use it here.
 
 **Foreground fallback** (use when `run_in_background` is unavailable, OR when you are a nested subagent):
 ```bash
 # Bash tool: timeout: 300000
-codex -c 'sandbox_mode="danger-full-access"' exec - > <TMPFILE> 2>&1 <<'CODEX_PROMPT'
+codex -c 'sandbox_mode="danger-full-access"' -c 'model="gpt-5.6-sol"' exec - > <TMPFILE> 2>&1 <<'CODEX_PROMPT'
 <constructed prompt>
 CODEX_PROMPT
 ```
-Bash blocks until Codex finishes or the tool timeout fires. On return, `Read <TMPFILE>` and then `rm <TMPFILE>`. Do not use `&` + `$!` polling — it adds PID tracking for no benefit once you control the Bash tool timeout. Do NOT use `trap 'rm -f $TMPFILE' EXIT` in any snippet that backgrounds a process — the trap fires when the launching shell exits, deleting the file before the background process writes to it.
+Bash blocks until Codex finishes or the tool timeout fires. On return, `Read <TMPFILE>` and then `rm <TMPFILE>`. Do NOT use `trap 'rm -f $TMPFILE' EXIT` in any snippet that backgrounds a process — the trap fires when the launching shell exits, deleting the file before the background process writes to it.
 
-3. Parse output: ignore startup logs, MCP registration/errors, **MCP tool-call traces** (e.g. `voicevox.text_to_speech`, `serena.find_symbol` — any inline JSON or tool invocation lines from the caller's MCP context leaking into Codex's output, including cases where Codex itself invokes an MCP tool mid-reasoning), reasoning traces, and trailing metadata (`tokens used`, `session id`, token summary). The substantive answer is the main plain-text block; Codex sometimes prints it once inline and echoes it again after metadata. **Tiebreaker when both copies are complete: use the post-metadata echo** — it is Codex's canonical final form.
+3. Parse output: ignore startup logs, MCP registration/errors, **MCP tool-call traces** (e.g. `voicevox.text_to_speech`, `serena.find_symbol` — any inline JSON or tool invocation lines from the caller's MCP context leaking into Codex's output, including cases where Codex itself invokes an MCP tool mid-reasoning), reasoning traces, and trailing metadata (`tokens used`, `session id`, token summary). The substantive answer is the main plain-text block; Codex sometimes prints it once inline and echoes it again after metadata (this happens because the response is finalised after the metadata block is written to stderr, then the final text is flushed to stdout). **Tiebreaker when both copies are complete: use the post-metadata echo** — it is Codex's canonical final form.
 
 4. Present both perspectives (labeled by model), highlight agreements and disagreements. Evaluate Codex's suggestion critically — do not blindly adopt it.
 


### PR DESCRIPTION


## Why

The codex-second-opinion skill relied on Codex CLI's default model, which can drift silently across releases and produce inconsistent second opinions. The skill's instructions also had minor structural issues: a `$!` polling warning lived in the foreground section where it didn't apply, the temporary-file path example was too abstract, and the post-metadata tiebreaker rule lacked a rationale.

## What

- Pin `gpt-5.6-sol` as the explicit model in both the background and foreground `codex exec` invocations, with a documented expectation to update the model string when a new generation (e.g. `gpt-5.7-sol`) is confirmed stable.
- Move the `$!` polling prohibition from the foreground fallback block into the background block's existing poll-loop ban, keeping each section's warnings scoped to its execution model.
- Replace the abstract path template with a concrete example path plus guidance for assembling it with common host-language primitives (Python f-strings, shell arithmetic).
- Add a one-sentence explanation of why the post-metadata echo is the canonical output (stderr metadata flush before final stdout flush).

## References

N/A
