### PR TITLE
Bump Codex default model from gpt-5.5 to gpt-5.6

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -1,7 +1,7 @@
 # See: https://developers.openai.com/codex/config-reference
 
 # Model
-model = "gpt-5.5"
+model = "gpt-5.6"
 model_reasoning_effort = "medium"
 model_reasoning_summary = "auto"
 model_verbosity = "medium"


### PR DESCRIPTION


## Why

The pinned Codex configuration still referenced `gpt-5.5`, which is now two generations behind the current recommended default (`gpt-5.6`). All new sessions would default to a stale model, missing the improvements in the 5.6 family.

## What

Updated the `model` key in `config/codex/config.toml` from `"gpt-5.5"` to `"gpt-5.6"`. The reasoning effort, summary mode, and verbosity were already at their recommended defaults (`medium` / `auto` / `medium`) and were left untouched — no behavioural change beyond the model swap.

## References

N/A
