### PR TITLE
Update agent tooling and add Library MCP access

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -40,7 +40,6 @@ startup_timeout_sec = 20
 tool_timeout_sec = 120
 
 [mcp_servers.library]
-type = "remote"
 url = "https://library.usabarashi.net/mcp"
 bearer_token_env_var = "LIBRARY_API_KEY"
 tool_timeout_sec = 120

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -1,8 +1,8 @@
 # See: https://developers.openai.com/codex/config-reference
 
 # Model
-model = "gpt-5.6"
-model_reasoning_effort = "medium"
+model = "gpt-5.6-sol"
+model_reasoning_effort = "low"
 model_reasoning_summary = "auto"
 model_verbosity = "medium"
 
@@ -13,9 +13,6 @@ web_search = "live"
 personality = "pragmatic"
 project_doc_fallback_filenames = ["CLAUDE.md", "GEMINI.md"]
 
-
-# Features
-notify = ["/Users/gen/.codex/computer-use/Codex Computer Use.app/Contents/SharedSupport/SkyComputerUseClient.app/Contents/MacOS/SkyComputerUseClient", "turn-ended", "--previous-notify", "[\"bash\",\"-lc\",\"afplay \\/System\\/Library\\/Sounds\\/Ping.aiff\"]"]
 
 [features]
 memories = true
@@ -42,6 +39,12 @@ args = []
 startup_timeout_sec = 20
 tool_timeout_sec = 120
 
+[mcp_servers.library]
+type = "remote"
+url = "https://library.usabarashi.net/mcp"
+bearer_token_env_var = "LIBRARY_API_KEY"
+tool_timeout_sec = 120
+
 # chrome-devtools-mcp drives Google Chrome via puppeteer-core; on PATH via
 # modules/shared/agents-common.nix. Flags (non-obvious reasons only):
 # - --isolated: ephemeral profile, never attaches to the real logged-in Chrome.
@@ -50,68 +53,12 @@ tool_timeout_sec = 120
 [mcp_servers.chrome-devtools]
 type = "stdio"
 command = "chrome-devtools-mcp"
-args = ["--isolated", "--headless", "--channel=stable", "--no-usage-statistics", "--no-performance-crux"]
+args = [
+    "--isolated",
+    "--headless",
+    "--channel=stable",
+    "--no-usage-statistics",
+    "--no-performance-crux",
+]
 startup_timeout_sec = 30
 tool_timeout_sec = 120
-
-[mcp_servers.node_repl]
-args = []
-command = "/Users/gen/Applications/Codex.app/Contents/Resources/cua_node/bin/node_repl"
-startup_timeout_sec = 120
-
-[mcp_servers.node_repl.env]
-NODE_REPL_NATIVE_PIPE_CONNECT_TIMEOUT_MS = "1000"
-NODE_REPL_NODE_MODULE_DIRS = "/Users/gen/Applications/Codex.app/Contents/Resources/cua_node/lib/node_modules"
-NODE_REPL_NODE_PATH = "/Users/gen/Applications/Codex.app/Contents/Resources/cua_node/bin/node"
-NODE_REPL_TRUSTED_CODE_PATHS = "/Users/gen/.codex"
-CODEX_HOME = "/Users/gen/.codex"
-NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S = "feca4d852d7d18eab5e217b18c8c80099fe667c330e836640fd7a48f362de525"
-BROWSER_USE_AVAILABLE_BACKENDS = "chrome,iab"
-NODE_REPL_INSTRUCTIONS_USE_CASE_BROWSER = "Control the in-app browser in conjunction with the Browser Plugin."
-NODE_REPL_INSTRUCTIONS_USE_CASE_CHROME = "Control the Chrome browser in conjunction with the Chrome Plugin. Prefer this method of controlling Chrome over alternatives (such as Computer Use) unless the user explicitly mentions an alternative."
-BROWSER_USE_CODEX_APP_BUILD_FLAVOR = "prod"
-BROWSER_USE_CODEX_APP_VERSION = "26.616.32156"
-CODEX_CLI_PATH = "/Users/gen/Applications/Codex.app/Contents/Resources/codex"
-
-[marketplaces.openai-bundled]
-last_updated = "2026-06-19T13:04:21Z"
-source_type = "local"
-source = "/Users/gen/.codex/.tmp/bundled-marketplaces/openai-bundled"
-
-[marketplaces.openai-primary-runtime]
-last_updated = "2026-06-20T04:11:12Z"
-source_type = "local"
-source = "/Users/gen/.cache/codex-runtimes/codex-primary-runtime/plugins/openai-primary-runtime"
-
-[plugins."browser@openai-bundled"]
-enabled = true
-
-[plugins."documents@openai-primary-runtime"]
-enabled = true
-
-[plugins."pdf@openai-primary-runtime"]
-enabled = true
-
-[plugins."spreadsheets@openai-primary-runtime"]
-enabled = true
-
-[plugins."presentations@openai-primary-runtime"]
-enabled = true
-
-[projects."/Users/gen/ghq/github.com/usabarashi/library"]
-trust_level = "trusted"
-
-[projects."/Users/gen/ghq/github.com/usabarashi/infrastructure"]
-trust_level = "trusted"
-
-[projects."/Users/gen/Documents/Codex/2026-06-19/opencode-web-terminal"]
-trust_level = "trusted"
-
-[projects."/Users/gen/ghq/github.com/usabarashi/openai-usage-tracker"]
-trust_level = "trusted"
-
-[projects."/Users/gen/ghq/github.com/usabarashi/nix-config"]
-trust_level = "trusted"
-
-[tui.model_availability_nux]
-"gpt-5.5" = 4

--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -23,6 +23,15 @@
       ],
       "timeout": 120000
     },
+    "library": {
+      "type": "remote",
+      "url": "https://library.usabarashi.net/mcp",
+      "headers": {
+        "Authorization": "Bearer {env:LIBRARY_API_KEY}"
+      },
+      "oauth": false,
+      "timeout": 120000
+    },
     "chrome-devtools": {
       "type": "local",
       "command": [

--- a/packages/antigravity-cli-bin/default.nix
+++ b/packages/antigravity-cli-bin/default.nix
@@ -10,13 +10,13 @@
 # https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/darwin_arm64.json
 # Pinned here so `agy update` cannot drift the store path out from under Nix.
 let
-  version = "1.1.8";
+  version = "1.1.11";
   # GCS build ID appended to the version in the bucket path; published alongside
   # `version` in the auto-updater manifest and bumped together with it.
-  buildId = "5636713813508096";
+  buildId = "4956531888881664";
   src = fetchurl {
     url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${version}-${buildId}/darwin-arm/cli_mac_arm64.tar.gz";
-    hash = "sha512-S8Jk59xnDSOLYqv3D3LzsN1O5m8VyWsWD6LTpt4OAvbLllhhM3c1/X/PoiFUnjTuTlj50RMrRPL64LQggWhmSQ==";
+    hash = "sha512-ikEOIDUKXSJVJv3kMWijdCYl2tMPQ9JUQj342Uektvh56tEmgBpSfj/yVcUI7S1e3GNSzvtIioSciIXAiVzSHw==";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/claude-code-bin/default.nix
+++ b/packages/claude-code-bin/default.nix
@@ -7,10 +7,10 @@
   stdenvNoCC,
 }:
 let
-  version = "2.1.220";
+  version = "2.1.224";
   src = fetchurl {
     url = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${version}/darwin-arm64/claude";
-    hash = "sha256-it3IV/P+ZNWgNor57lAyG1CvtKaRi6PvAYq4T1274IE=";
+    hash = "sha256-OR350qsE5M8yGZM1cgrHcVpYLpHq7P1NIZihb1fqWbM=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/packages/codex-bin/default.nix
+++ b/packages/codex-bin/default.nix
@@ -1,4 +1,4 @@
-# Codex CLI native binary fetched from GitHub Releases, managed independently of nixpkgs.
+# Codex CLI package fetched from GitHub Releases, managed independently of nixpkgs.
 #
 # Update workflow: update `version` and `hash` below, then deploy.
 {
@@ -7,11 +7,11 @@
   stdenvNoCC,
 }:
 let
-  version = "0.146.0";
-  asset = "codex-aarch64-apple-darwin";
+  version = "0.147.0";
+  asset = "codex-package-aarch64-apple-darwin";
   src = fetchurl {
     url = "https://github.com/openai/codex/releases/download/rust-v${version}/${asset}.tar.gz";
-    hash = "sha256-J1ATLTAOZPHb/7lePZE/2cnceBK8jhvOXGE1cki3kp4=";
+    hash = "sha256-F7KYTrIrYH49DCVyglL8kPUQ5Ha605ptn0XNsapoVDI=";
   };
 in
 stdenvNoCC.mkDerivation {
@@ -20,9 +20,19 @@ stdenvNoCC.mkDerivation {
   sourceRoot = ".";
   dontBuild = true;
   dontStrip = true;
-  installPhase = "install -Dm755 ${asset} $out/bin/codex";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 bin/codex "$out/bin/codex"
+    install -Dm755 bin/codex-code-mode-host "$out/bin/codex-code-mode-host"
+    install -Dm755 codex-path/rg "$out/codex-path/rg"
+    install -Dm755 codex-resources/zsh/bin/zsh "$out/codex-resources/zsh/bin/zsh"
+    install -Dm644 codex-package.json "$out/codex-package.json"
+
+    runHook postInstall
+  '';
   meta = {
-    description = "Pre-built Codex CLI native binary (darwin-arm64), version-pinned";
+    description = "Pre-built Codex CLI package (darwin-arm64), version-pinned";
     license = lib.licenses.asl20;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     mainProgram = "codex";

--- a/packages/opencode-bin/default.nix
+++ b/packages/opencode-bin/default.nix
@@ -9,11 +9,11 @@
   unzip,
 }:
 let
-  version = "1.18.10";
+  version = "1.18.15";
   asset = "opencode-darwin-arm64";
   src = fetchurl {
     url = "https://github.com/sst/opencode/releases/download/v${version}/${asset}.zip";
-    hash = "sha256-ZB/i5l5C23bC0y21+FVzw2gqjHL4LQFWipIqj+zMRlg=";
+    hash = "sha256-vWC1fLn+BJSlNSyAdCTTbW14U89tvduXBlx8zTxdORw=";
   };
 in
 stdenvNoCC.mkDerivation {


### PR DESCRIPTION


## Why
The pinned agent CLIs were behind their current releases, and the latest Codex release no longer fits the existing single-binary packaging assumption. Codex and OpenCode also needed consistent authenticated access to the Library service without committing credentials.

## What
- Keep the agent tools version-pinned in Nix so upgrades remain reproducible, while adapting Codex to install the complete upstream package instead of extracting only its main executable.
- Configure Library as the same remote MCP service in Codex and OpenCode, with authentication supplied through `LIBRARY_API_KEY` rather than embedded in the repository.
- Use the Codex-optimized model at low reasoning effort as the interactive default, and remove app-generated state that does not belong in the declarative configuration.

## References
N/A
